### PR TITLE
feat: formalize proposal lifecycle in Lean

### DIFF
--- a/docs/docs/event-classification.md
+++ b/docs/docs/event-classification.md
@@ -65,7 +65,9 @@ event. They also accumulate for lifecycle tracking until:
 
 **Lean predicates:** `EventClass`, `event_trichotomy`,
 `decision_not_proposal`, `decision_not_response`,
-`proposal_not_response`
+`proposal_not_response`,
+`Resolution`, `ProposalStatus`, `TrackedProposal`,
+`ProposalRegistry`
 
 ## Proposal lifecycle
 
@@ -121,6 +123,41 @@ event. This is why the server is a circle member with its own KEL
 The server-emitted decision is a regular event in the global
 sequence. Clients can verify its signature against the server's
 KEL just like any other event.
+
+### Response validation
+
+A member can respond to an open proposal at most once. The
+protocol tracks respondents per proposal and rejects duplicate
+responses. Only open proposals accept responses — once resolved,
+no further responses are accepted.
+
+### Timeout obligation
+
+Every proposal has a mandatory deadline. The sequencer must
+resolve any open proposal whose deadline has passed. This is a
+**liveness obligation** on the sequencer: as long as the sequencer
+is running, no proposal remains open past its deadline. Resolved
+proposals trivially satisfy this obligation.
+
+### Admin majority as a threshold gate
+
+Admin role changes (promote/demote) use the proposal mechanism
+with **admin majority** as the threshold gate. The threshold
+checks whether the number of admin respondents meets the majority
+threshold for the current circle. A single admin trivially meets
+majority with their own response, which is why a lone admin can
+demote themselves.
+
+**Lean predicates:** `openProposal`, `addResponse`,
+`resolveProposal`, `findProposal`,
+`open_proposal_is_open`, `open_proposal_no_responses`,
+`resolve_resolved_noop`, `resolution_dichotomy`,
+`threshold_is_positive`, `proposer_positive_is_positive`,
+`proposer_negative_is_negative`, `timeout_is_negative`,
+`timeoutObligation`, `resolved_satisfies_obligation`,
+`adminMajorityMet`, `single_admin_majority_self`,
+`hasNotResponded`, `canRespond`,
+`fresh_proposal_accepts_response`
 
 ## All event classes contribute to the fold
 

--- a/lean/KelCircle.lean
+++ b/lean/KelCircle.lean
@@ -8,3 +8,4 @@ import KelCircle.Events
 import KelCircle.Fold
 import KelCircle.Invariants
 import KelCircle.BaseDecisions
+import KelCircle.Proposals

--- a/lean/KelCircle/Proposals.lean
+++ b/lean/KelCircle/Proposals.lean
@@ -1,0 +1,224 @@
+-- Proposals: lifecycle, resolution, and invariants
+--
+-- A proposal opens a coordination round. It carries a mandatory
+-- timeout and an optional threshold gate. Responses accumulate
+-- until one of four resolution conditions is met. The sequencer
+-- emits a decision event to close the proposal.
+
+import KelCircle.BaseDecisions
+
+namespace KelCircle
+
+-- How a proposal was resolved
+inductive Resolution where
+  | thresholdReached    -- enough responses satisfied the threshold gate
+  | proposerPositive    -- proposer closed with a positive outcome
+  | proposerNegative    -- proposer cancelled
+  | timeout             -- deadline passed without resolution
+  deriving Repr, BEq, DecidableEq
+
+-- A resolution is either positive (fold advances with responses)
+-- or negative (fold records rejection, no payload applied)
+def Resolution.isPositive : Resolution → Bool
+  | .thresholdReached  => true
+  | .proposerPositive  => true
+  | .proposerNegative  => false
+  | .timeout           => false
+
+-- Proposal status in the lifecycle
+inductive ProposalStatus where
+  | open               -- accepting responses
+  | resolved (r : Resolution)  -- closed with a resolution
+  deriving Repr, BEq, DecidableEq
+
+-- A tracked proposal: the protocol-level bookkeeping
+-- Content types are abstract (application-defined)
+structure TrackedProposal (π ρ : Type) where
+  proposalId   : ProposalId
+  content      : π
+  proposer     : MemberId
+  deadline     : Timestamp
+  responses    : List ρ
+  respondents  : List MemberId
+  status       : ProposalStatus
+
+-- The proposal registry: all tracked proposals
+abbrev ProposalRegistry (π ρ : Type) := List (TrackedProposal π ρ)
+
+-- Lookup a proposal by id
+def findProposal {π ρ : Type}
+    (reg : ProposalRegistry π ρ) (pid : ProposalId)
+    : Option (TrackedProposal π ρ) :=
+  reg.find? (fun p => p.proposalId == pid)
+
+-- A proposal is open (pattern matching for proof-friendliness)
+def TrackedProposal.isOpen {π ρ : Type}
+    (p : TrackedProposal π ρ) : Bool :=
+  match p.status with
+  | .open => true
+  | .resolved _ => false
+
+-- A proposal is resolved
+def TrackedProposal.isResolved {π ρ : Type}
+    (p : TrackedProposal π ρ) : Bool :=
+  match p.status with
+  | .resolved _ => true
+  | .open => false
+
+-- Open a new proposal in the registry
+def openProposal {π ρ : Type}
+    (reg : ProposalRegistry π ρ) (pid : ProposalId)
+    (content : π) (proposer : MemberId)
+    (deadline : Timestamp) : ProposalRegistry π ρ :=
+  { proposalId := pid
+  , content := content
+  , proposer := proposer
+  , deadline := deadline
+  , responses := []
+  , respondents := []
+  , status := .open
+  } :: reg
+
+-- Add a response to an open proposal
+def addResponse {π ρ : Type}
+    (reg : ProposalRegistry π ρ) (pid : ProposalId)
+    (responder : MemberId) (response : ρ)
+    : ProposalRegistry π ρ :=
+  reg.map (fun p =>
+    if p.proposalId == pid && p.isOpen then
+      { p with
+        responses := response :: p.responses
+        respondents := responder :: p.respondents }
+    else p)
+
+-- Resolve a proposal with a given resolution
+def resolveProposal {π ρ : Type}
+    (reg : ProposalRegistry π ρ) (pid : ProposalId)
+    (r : Resolution) : ProposalRegistry π ρ :=
+  reg.map (fun p =>
+    if p.proposalId == pid && p.isOpen then
+      { p with status := .resolved r }
+    else p)
+
+-------------------------------------------------------------------
+-- Invariants
+-------------------------------------------------------------------
+
+-- A newly opened proposal is open
+theorem open_proposal_is_open {π ρ : Type}
+    (reg : ProposalRegistry π ρ) (pid : ProposalId)
+    (content : π) (proposer : MemberId) (deadline : Timestamp) :
+    (openProposal reg pid content proposer deadline).head?.map
+      TrackedProposal.isOpen = some true := by
+  simp [openProposal, TrackedProposal.isOpen]
+
+-- A newly opened proposal has no responses
+theorem open_proposal_no_responses {π ρ : Type}
+    (reg : ProposalRegistry π ρ) (pid : ProposalId)
+    (content : π) (proposer : MemberId) (deadline : Timestamp) :
+    (openProposal reg pid content proposer deadline).head?.map
+      (fun p => p.responses.length) = some 0 := by
+  simp [openProposal]
+
+-- Resolution is idempotent: resolving an already-resolved proposal
+-- does not change it (the isOpen check prevents it)
+theorem resolve_resolved_noop {π ρ : Type}
+    (p : TrackedProposal π ρ) (r1 r2 : Resolution)
+    (hr : p.status = .resolved r1) :
+    (if p.proposalId == p.proposalId && p.isOpen then
+       { p with status := .resolved r2 }
+     else p) = p := by
+  simp [TrackedProposal.isOpen, hr]
+
+-- Every resolution is either positive or negative
+theorem resolution_dichotomy (r : Resolution) :
+    r.isPositive = true ∨ r.isPositive = false := by
+  cases r <;> simp [Resolution.isPositive]
+
+-- Threshold and proposer-positive are positive
+theorem threshold_is_positive :
+    Resolution.thresholdReached.isPositive = true := rfl
+
+theorem proposer_positive_is_positive :
+    Resolution.proposerPositive.isPositive = true := rfl
+
+-- Proposer-negative and timeout are negative
+theorem proposer_negative_is_negative :
+    Resolution.proposerNegative.isPositive = false := rfl
+
+theorem timeout_is_negative :
+    Resolution.timeout.isPositive = false := rfl
+
+-------------------------------------------------------------------
+-- Timeout guarantee: every proposal with a deadline will resolve
+-------------------------------------------------------------------
+
+-- If the current time exceeds the deadline and the proposal is
+-- still open, it must be resolved as timeout. This is an
+-- obligation on the sequencer, not a theorem about data — we
+-- express it as a predicate that the sequencer must maintain.
+def timeoutObligation {π ρ : Type}
+    (p : TrackedProposal π ρ) (now : Timestamp) : Prop :=
+  now > p.deadline → p.isOpen = true → False
+
+-- Any resolved proposal satisfies the timeout obligation
+theorem resolved_satisfies_obligation {π ρ : Type}
+    (p : TrackedProposal π ρ) (now : Timestamp)
+    (r : Resolution) (hr : p.status = .resolved r) :
+    timeoutObligation p now := by
+  intro _ hopen
+  simp [TrackedProposal.isOpen, hr] at hopen
+
+-------------------------------------------------------------------
+-- Admin majority proposals (role changes)
+-------------------------------------------------------------------
+
+-- Admin role changes use the proposal mechanism with admin
+-- majority as the threshold. This connects base decisions
+-- (changeRole) to the proposal lifecycle.
+
+-- An admin majority proposal: the threshold gate checks whether
+-- the number of admin respondents meets the majority threshold.
+def adminMajorityMet (s : CircleState) (respondents : List MemberId) : Bool :=
+  let adminRespondents := respondents.filter (fun m => isAdminB s m)
+  adminRespondents.length >= majority (adminCount s)
+
+-- Single admin trivially meets majority with their own response
+theorem single_admin_majority_self
+    (s : CircleState) (aid : MemberId)
+    (hadmin : isAdminB s aid = true)
+    (hcount : adminCount s = 1) :
+    adminMajorityMet s [aid] = true := by
+  simp [adminMajorityMet, hadmin, hcount, majority]
+
+-------------------------------------------------------------------
+-- Response validation
+-------------------------------------------------------------------
+
+-- A member can only respond once per proposal
+def hasNotResponded {π ρ : Type}
+    (p : TrackedProposal π ρ) (m : MemberId) : Bool :=
+  !(p.respondents.any (fun r => r == m))
+
+-- Only open proposals accept responses
+def canRespond {π ρ : Type}
+    (p : TrackedProposal π ρ) (m : MemberId) : Bool :=
+  p.isOpen && hasNotResponded p m
+
+-- A fresh proposal accepts any member's response
+theorem fresh_proposal_accepts_response {π ρ : Type}
+    (pid : ProposalId) (content : π)
+    (proposer : MemberId) (deadline : Timestamp)
+    (m : MemberId) :
+    let p : TrackedProposal π ρ :=
+      { proposalId := pid
+      , content := content
+      , proposer := proposer
+      , deadline := deadline
+      , responses := []
+      , respondents := []
+      , status := .open }
+    canRespond p m = true := by
+  simp [canRespond, TrackedProposal.isOpen, hasNotResponded, List.any]
+
+end KelCircle


### PR DESCRIPTION
## Summary
- New `Proposals.lean` formalizing the proposal lifecycle
- Resolution type with four modes: threshold, proposer-positive, proposer-negative, timeout
- TrackedProposal registry with open/resolve operations
- Timeout obligation predicate (liveness guarantee on sequencer)
- Admin majority threshold gate connecting role changes to proposals
- Response validation: open check + duplicate prevention
- All proofs compile with no sorry

## Lean definitions
- Types: `Resolution`, `ProposalStatus`, `TrackedProposal`, `ProposalRegistry`
- Operations: `openProposal`, `addResponse`, `resolveProposal`, `findProposal`
- Predicates: `timeoutObligation`, `adminMajorityMet`, `canRespond`, `hasNotResponded`
- Theorems: `open_proposal_is_open`, `resolve_resolved_noop`, `resolved_satisfies_obligation`, `single_admin_majority_self`, `fresh_proposal_accepts_response`

## Test plan
- [x] `lake build` passes with no sorry
- [x] `just ci` passes locally (Lean + docs)
- [ ] CI green on GitHub