### PR TITLE
feat: Haskell library skeleton mirroring Lean formalization

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ test:
 
 # Format Haskell sources
 format:
-    fourmolu -i lib/**/*.hs
+    fourmolu -i lib/**/*.hs lib/KelCircle.hs
 
 # Lint Haskell sources
 lint:
@@ -42,8 +42,12 @@ lint-client:
 test-client:
     cd client && spago test -p kel-circle-client
 
-# Full CI check (design phase: only Lean proofs and docs)
-ci: lean build-docs
+# Full CI check
+ci: format-check lint build lean build-docs
+
+# Check Haskell formatting (no modification)
+format-check:
+    fourmolu --mode check lib/**/*.hs lib/KelCircle.hs
 
 # Build documentation
 build-docs:

--- a/kel-circle.cabal
+++ b/kel-circle.cabal
@@ -31,12 +31,22 @@ common language
 common opts-lib
   ghc-options:
     -Wall -Werror -Wunused-imports -Wunused-packages
-    -Wmissing-export-lists -Wname-shadowing -Wredundant-constraints
+    -Wmissing-export-lists -Wname-shadowing
+    -Wredundant-constraints
 
 library
   import:          language, opts-lib
   hs-source-dirs:  lib
   exposed-modules:
     KelCircle
+    KelCircle.Events
+    KelCircle.Fold
+    KelCircle.Gate
+    KelCircle.Processing
+    KelCircle.Proposals
+    KelCircle.Sequence
+    KelCircle.State
+    KelCircle.Types
   build-depends:
     , base  >=4.18 && <5
+    , text  >=2.0  && <3

--- a/lib/KelCircle.hs
+++ b/lib/KelCircle.hs
@@ -4,6 +4,40 @@ Description : Synchronized multi-KEL circle protocol
 Copyright   : (c) 2026 Paolo Veronelli
 License     : Apache-2.0
 
-Top-level module for the kel-circle library.
+Top-level module for the kel-circle library. Re-exports
+all public API modules.
 -}
-module KelCircle () where
+module KelCircle
+    ( -- * Core types
+      module KelCircle.Types
+
+      -- * Global sequence
+    , module KelCircle.Sequence
+
+      -- * Event classes and decisions
+    , module KelCircle.Events
+
+      -- * State fold
+    , module KelCircle.Fold
+
+      -- * Circle state and membership
+    , module KelCircle.State
+
+      -- * Two-level gate
+    , module KelCircle.Gate
+
+      -- * Proposal lifecycle
+    , module KelCircle.Proposals
+
+      -- * Event processing pipeline
+    , module KelCircle.Processing
+    ) where
+
+import KelCircle.Events
+import KelCircle.Fold
+import KelCircle.Gate
+import KelCircle.Processing
+import KelCircle.Proposals
+import KelCircle.Sequence
+import KelCircle.State
+import KelCircle.Types

--- a/lib/KelCircle/Events.hs
+++ b/lib/KelCircle/Events.hs
@@ -1,0 +1,130 @@
+{- |
+Module      : KelCircle.Events
+Description : Event classes and base decisions
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+The three event classes (decision, proposal, response)
+and base decisions (membership operations). Mirrors Lean
+@KelCircle.Events@ and @KelCircle.BaseDecisions@.
+-}
+module KelCircle.Events
+    ( -- * Event classes
+      EventClass (..)
+    , isDecision
+    , isProposal
+    , isResponse
+
+      -- * Base decisions
+    , BaseDecision (..)
+
+      -- * Proposal resolution
+    , Resolution (..)
+    , isPositive
+
+      -- * Circle events (unified)
+    , CircleEvent (..)
+    ) where
+
+import KelCircle.Types
+    ( MemberId
+    , ProposalId
+    , Role
+    , Timestamp
+    )
+
+{- | The three event classes, parameterized by
+application content types.
+Mirrors Lean @EventClass@.
+
+Type parameters:
+
+* @d@ — decision content
+* @p@ — proposal content
+* @r@ — response content
+-}
+data EventClass d p r
+    = -- | A straight decision (changes the fold)
+      Decision d
+    | -- | Opens a coordination round
+      Proposal p Timestamp MemberId
+    | -- | References an open proposal
+      Response r ProposalId MemberId
+    deriving stock (Show, Eq)
+
+-- | Is this event a decision?
+isDecision :: EventClass d p r -> Bool
+isDecision (Decision _) = True
+isDecision _ = False
+
+-- | Is this event a proposal?
+isProposal :: EventClass d p r -> Bool
+isProposal (Proposal{}) = True
+isProposal _ = False
+
+-- | Is this event a response?
+isResponse :: EventClass d p r -> Bool
+isResponse (Response{}) = True
+isResponse _ = False
+
+{- | Base decisions: protocol-level membership operations.
+Mirrors Lean @BaseDecision@.
+-}
+data BaseDecision
+    = -- | Add a member with a given role
+      IntroduceMember MemberId Role
+    | -- | Remove a member from the circle
+      RemoveMember MemberId
+    | -- | Change a member's role
+      ChangeRole MemberId Role
+    | -- | Replace the sequencer identity
+      RotateSequencer MemberId
+    deriving stock (Show, Eq)
+
+{- | How a proposal was resolved.
+Mirrors Lean @Resolution@.
+-}
+data Resolution
+    = -- | Enough responses met the threshold gate
+      ThresholdReached
+    | -- | Proposer closed with positive outcome
+      ProposerPositive
+    | -- | Proposer cancelled
+      ProposerNegative
+    | -- | Deadline passed without resolution
+      Timeout
+    deriving stock (Show, Eq)
+
+{- | A resolution is positive if it carries responses
+into the fold.
+Mirrors Lean @Resolution.isPositive@.
+-}
+isPositive :: Resolution -> Bool
+isPositive ThresholdReached = True
+isPositive ProposerPositive = True
+isPositive ProposerNegative = False
+isPositive Timeout = False
+
+{- | The unified circle event type. Combines base
+decisions, application decisions, proposals,
+responses, and resolution events.
+Mirrors Lean @CircleEvent@.
+
+Type parameters:
+
+* @d@ — application decision content
+* @p@ — proposal content
+* @r@ — response content
+-}
+data CircleEvent d p r
+    = -- | A base decision (membership operation)
+      CEBaseDecision BaseDecision
+    | -- | An application decision (domain-specific)
+      CEAppDecision d
+    | -- | Opens a proposal with deadline
+      CEProposal p Timestamp
+    | -- | Responds to an open proposal
+      CEResponse r ProposalId
+    | -- | Server-emitted resolution
+      CEResolveProposal ProposalId Resolution
+    deriving stock (Show, Eq)

--- a/lib/KelCircle/Fold.hs
+++ b/lib/KelCircle/Fold.hs
@@ -1,0 +1,60 @@
+{- |
+Module      : KelCircle.Fold
+Description : State fold over the global sequence
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Generic fold over sequenced events. Every event in the
+global sequence contributes to the resulting state.
+Mirrors Lean @KelCircle.Fold@.
+-}
+module KelCircle.Fold
+    ( -- * Generic fold
+      foldAll
+
+      -- * Two-layer fold
+    , TwoLayerState (..)
+    , twoLayerFold
+    ) where
+
+import KelCircle.Sequence (SequencedEvent (..))
+
+{- | Fold all events in the global sequence, oldest-first.
+Every event contributes to the resulting state.
+Mirrors Lean @foldAll@.
+-}
+foldAll
+    :: (s -> a -> s)
+    -> s
+    -> [SequencedEvent a]
+    -> s
+foldAll f = foldl (\acc e -> f acc (seqPayload e))
+
+{- | Two-layer state: base fold + application fold.
+Mirrors Lean @TwoLayerState@.
+-}
+data TwoLayerState b g = TwoLayerState
+    { tlBase :: b
+    -- ^ Base-layer state (membership, roles)
+    , tlApp :: g
+    -- ^ Application-layer state
+    }
+    deriving stock (Show, Eq)
+
+{- | Compose two fold functions into a two-layer fold.
+Both layers see every sequenced event.
+Mirrors Lean @twoLayerFold@.
+-}
+twoLayerFold
+    :: (b -> a -> b)
+    -> (g -> a -> g)
+    -> TwoLayerState b g
+    -> [SequencedEvent a]
+    -> TwoLayerState b g
+twoLayerFold fBase fApp =
+    foldAll
+        ( \s a ->
+            TwoLayerState
+                (fBase (tlBase s) a)
+                (fApp (tlApp s) a)
+        )

--- a/lib/KelCircle/Gate.hs
+++ b/lib/KelCircle/Gate.hs
@@ -1,0 +1,104 @@
+{- |
+Module      : KelCircle.Gate
+Description : Two-level semantic gate
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+The two-level gate: base gate (protocol-level access
+control) composed with application gate. Mirrors Lean
+@KelCircle.BaseDecisions@ gate functions and
+@KelCircle.Processing@ gate functions.
+-}
+module KelCircle.Gate
+    ( -- * Sequencer protection
+      protectsSequencer
+    , requiresMajority
+
+      -- * Base gate
+    , baseGate
+
+      -- * Full gate (base + app)
+    , fullGate
+
+      -- * Admin majority
+    , hasAdminMajority
+    ) where
+
+import KelCircle.Events (BaseDecision (..))
+import KelCircle.State
+    ( CircleState
+    , adminCount
+    , isAdmin
+    , isBootstrap
+    , majority
+    )
+import KelCircle.Types (MemberId, Role (..))
+
+{- | The sequencer cannot be removed or promoted to
+admin.
+Mirrors Lean @protectsSequencer@.
+-}
+protectsSequencer :: MemberId -> BaseDecision -> Bool
+protectsSequencer sid = \case
+    RemoveMember mid -> mid /= sid
+    ChangeRole mid Admin -> mid /= sid
+    _ -> True
+
+{- | Admin role changes require majority (proposal),
+not a straight decision.
+Mirrors Lean @requiresMajority@.
+-}
+requiresMajority :: BaseDecision -> Bool
+requiresMajority = \case
+    IntroduceMember _ Admin -> True
+    ChangeRole _ Admin -> True
+    ChangeRole _ Member -> True
+    _ -> False
+
+{- | Base gate for straight decisions.
+In bootstrap: only admin introduction.
+In normal: signer must be admin, and the decision
+must not require majority.
+Mirrors Lean @baseGate@.
+-}
+baseGate
+    :: CircleState
+    -> MemberId
+    -> MemberId
+    -> BaseDecision
+    -> Bool
+baseGate s signer sid d =
+    protectsSequencer sid d
+        && if isBootstrap s
+            then case d of
+                IntroduceMember _ Admin -> True
+                _ -> False
+            else isAdmin s signer && not (requiresMajority d)
+
+{- | The full gate composes base gate and application
+gate.
+Mirrors Lean @fullGate@.
+-}
+fullGate
+    :: CircleState
+    -> MemberId
+    -> MemberId
+    -> BaseDecision
+    -> g
+    -> (g -> BaseDecision -> Bool)
+    -> Bool
+fullGate s signer sid d appState appGate =
+    baseGate s signer sid d
+        && appGate appState d
+
+{- | Check whether admin respondents meet the majority
+threshold.
+Mirrors Lean @adminMajorityMet@.
+-}
+hasAdminMajority
+    :: CircleState -> [MemberId] -> Bool
+hasAdminMajority s respondents =
+    let adminRespondents =
+            filter (isAdmin s) respondents
+    in  length adminRespondents
+            >= majority (adminCount s)

--- a/lib/KelCircle/Processing.hs
+++ b/lib/KelCircle/Processing.hs
@@ -1,0 +1,256 @@
+{- |
+Module      : KelCircle.Processing
+Description : Event processing pipeline
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+The event processing pipeline: validates events through
+the two-level gate and applies them to the full state.
+Mirrors Lean @KelCircle.Processing@.
+-}
+module KelCircle.Processing
+    ( -- * Full state
+      FullState (..)
+    , initFullState
+
+      -- * Gate functions
+    , gateBaseDecision
+    , gateAppDecision
+    , gateProposal
+    , gateResponse
+    , gateResolve
+
+      -- * Apply functions
+    , applyBase
+    , applyAppDecision
+    , applyProposal
+    , applyResponse
+    , applyResolve
+    ) where
+
+import KelCircle.Events
+    ( BaseDecision (..)
+    , Resolution
+    )
+import KelCircle.Gate (fullGate)
+import KelCircle.Proposals qualified as P
+import KelCircle.State
+    ( Circle (..)
+    , applyBaseDecision
+    , emptyCircle
+    , isMember
+    )
+import KelCircle.Types
+    ( MemberId
+    , ProposalId
+    , Role (..)
+    , Timestamp
+    )
+
+{- | The complete state maintained by the sequencer.
+Mirrors Lean @FullState@.
+
+Type parameters:
+
+* @g@ — application fold state
+* @p@ — proposal content
+* @r@ — response content
+-}
+data FullState g p r = FullState
+    { fsCircle :: Circle
+    -- ^ Base state + sequencer id
+    , fsAppState :: g
+    -- ^ Application fold state
+    , fsProposals :: P.ProposalRegistry p r
+    -- ^ Tracked proposals
+    , fsNextSeq :: Int
+    -- ^ Next sequence number
+    }
+    deriving stock (Show, Eq)
+
+{- | Initial state for a circle after genesis.
+The sequencer introduces itself as event 0.
+Mirrors Lean @initFullState@.
+-}
+initFullState
+    :: MemberId -> g -> FullState g p r
+initFullState sid initApp =
+    FullState
+        { fsCircle = genesis sid
+        , fsAppState = initApp
+        , fsProposals = []
+        , fsNextSeq = 1
+        }
+  where
+    genesis sid' =
+        applyBaseDecision
+            ( Circle
+                { circleState = emptyCircle
+                , sequencerId = sid'
+                }
+            )
+            (IntroduceMember sid' Member)
+
+-- ---------------------------------------------------------------
+-- Gate functions
+-- ---------------------------------------------------------------
+
+{- | Gate for base decisions: uses the two-level gate.
+Mirrors Lean @gateBaseDecision@.
+-}
+gateBaseDecision
+    :: FullState g p r
+    -> MemberId
+    -> BaseDecision
+    -> (g -> BaseDecision -> Bool)
+    -> Bool
+gateBaseDecision s signer d =
+    fullGate
+        (circleState (fsCircle s))
+        signer
+        (sequencerId (fsCircle s))
+        d
+        (fsAppState s)
+
+{- | Gate for application decisions: signer must be a
+member and pass the app gate.
+Mirrors Lean @gateAppDecision@.
+-}
+gateAppDecision
+    :: FullState g p r
+    -> MemberId
+    -> d
+    -> (g -> d -> Bool)
+    -> Bool
+gateAppDecision s signer content appGate =
+    isMember (circleState (fsCircle s)) signer
+        && appGate (fsAppState s) content
+
+{- | Gate for proposals: signer must be a member and
+pass the app gate.
+Mirrors Lean @gateProposal@.
+-}
+gateProposal
+    :: FullState g p r
+    -> MemberId
+    -> p
+    -> (g -> p -> Bool)
+    -> Bool
+gateProposal s signer content appGate =
+    isMember (circleState (fsCircle s)) signer
+        && appGate (fsAppState s) content
+
+{- | Gate for responses: signer must be a member,
+proposal must be open, signer must not have already
+responded.
+Mirrors Lean @gateResponse@.
+-}
+gateResponse
+    :: FullState g p r
+    -> MemberId
+    -> ProposalId
+    -> Bool
+gateResponse s signer pid =
+    isMember (circleState (fsCircle s)) signer
+        && case P.findProposal (fsProposals s) pid of
+            Just tp -> P.canRespond tp signer
+            Nothing -> False
+
+{- | Gate for resolve: only the sequencer can resolve.
+Mirrors Lean @gateResolve@.
+-}
+gateResolve
+    :: FullState g p r -> MemberId -> Bool
+gateResolve s signer =
+    signer == sequencerId (fsCircle s)
+
+-- ---------------------------------------------------------------
+-- Apply functions
+-- ---------------------------------------------------------------
+
+{- | Apply a base decision to the full state.
+Mirrors Lean @applyBase@.
+-}
+applyBase
+    :: FullState g p r
+    -> BaseDecision
+    -> FullState g p r
+applyBase s d =
+    s
+        { fsCircle =
+            applyBaseDecision (fsCircle s) d
+        , fsNextSeq = fsNextSeq s + 1
+        }
+
+{- | Apply an application decision (fold update only).
+Mirrors Lean @applyAppDecision@.
+-}
+applyAppDecision
+    :: FullState g p r
+    -> d
+    -> (g -> d -> g)
+    -> FullState g p r
+applyAppDecision s content fApp =
+    s
+        { fsAppState = fApp (fsAppState s) content
+        , fsNextSeq = fsNextSeq s + 1
+        }
+
+{- | Apply a proposal: register it as open.
+Mirrors Lean @applyProposal@.
+-}
+applyProposal
+    :: FullState g p r
+    -> p
+    -> MemberId
+    -> Timestamp
+    -> FullState g p r
+applyProposal s content proposer deadline =
+    s
+        { fsProposals =
+            P.openProposal
+                (fsProposals s)
+                (fsNextSeq s)
+                content
+                proposer
+                deadline
+        , fsNextSeq = fsNextSeq s + 1
+        }
+
+{- | Apply a response: add to proposal.
+Mirrors Lean @applyResponse@.
+-}
+applyResponse
+    :: FullState g p r
+    -> r
+    -> MemberId
+    -> ProposalId
+    -> FullState g p r
+applyResponse s content responder pid =
+    s
+        { fsProposals =
+            P.addResponse
+                (fsProposals s)
+                pid
+                responder
+                content
+        , fsNextSeq = fsNextSeq s + 1
+        }
+
+{- | Apply a resolution: close the proposal.
+Mirrors Lean @applyResolve@.
+-}
+applyResolve
+    :: FullState g p r
+    -> ProposalId
+    -> Resolution
+    -> FullState g p r
+applyResolve s pid r =
+    s
+        { fsProposals =
+            P.resolveProposal
+                (fsProposals s)
+                pid
+                r
+        , fsNextSeq = fsNextSeq s + 1
+        }

--- a/lib/KelCircle/Proposals.hs
+++ b/lib/KelCircle/Proposals.hs
@@ -1,0 +1,186 @@
+{- |
+Module      : KelCircle.Proposals
+Description : Proposal lifecycle and tracking
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Proposal lifecycle: open, respond, resolve. Tracks
+proposal status, responses, and respondents. Mirrors
+Lean @KelCircle.Proposals@.
+-}
+module KelCircle.Proposals
+    ( -- * Proposal status
+      ProposalStatus (..)
+    , isOpen
+    , isResolved
+
+      -- * Tracked proposals
+    , TrackedProposal (..)
+    , ProposalRegistry
+
+      -- * Operations
+    , findProposal
+    , openProposal
+    , addResponse
+    , resolveProposal
+
+      -- * Response validation
+    , hasNotResponded
+    , canRespond
+    ) where
+
+import KelCircle.Events (Resolution)
+import KelCircle.Types
+    ( MemberId
+    , ProposalId
+    , Timestamp
+    )
+
+{- | Proposal status in the lifecycle.
+Mirrors Lean @ProposalStatus@.
+-}
+data ProposalStatus
+    = -- | Accepting responses
+      Open
+    | -- | Closed with a resolution
+      Resolved Resolution
+    deriving stock (Show, Eq)
+
+-- | Is the proposal open?
+isOpen :: ProposalStatus -> Bool
+isOpen Open = True
+isOpen _ = False
+
+-- | Is the proposal resolved?
+isResolved :: ProposalStatus -> Bool
+isResolved (Resolved _) = True
+isResolved _ = False
+
+{- | A tracked proposal: protocol-level bookkeeping.
+Content types are abstract (application-defined).
+Mirrors Lean @TrackedProposal@.
+
+Type parameters:
+
+* @p@ — proposal content
+* @r@ — response content
+-}
+data TrackedProposal p r = TrackedProposal
+    { tpProposalId :: ProposalId
+    -- ^ Sequence index where opened
+    , tpContent :: p
+    -- ^ Application-defined proposal content
+    , tpProposer :: MemberId
+    -- ^ Who proposed
+    , tpDeadline :: Timestamp
+    -- ^ Mandatory timeout deadline
+    , tpResponses :: [r]
+    -- ^ Accumulated responses
+    , tpRespondents :: [MemberId]
+    -- ^ Who has responded
+    , tpStatus :: ProposalStatus
+    -- ^ Current lifecycle status
+    }
+    deriving stock (Show, Eq)
+
+{- | The proposal registry: all tracked proposals.
+Mirrors Lean @ProposalRegistry@.
+-}
+type ProposalRegistry p r = [TrackedProposal p r]
+
+{- | Lookup a proposal by id.
+Mirrors Lean @findProposal@.
+-}
+findProposal
+    :: ProposalRegistry p r
+    -> ProposalId
+    -> Maybe (TrackedProposal p r)
+findProposal reg pid =
+    case filter
+        (\tp -> tpProposalId tp == pid)
+        reg of
+        (x : _) -> Just x
+        [] -> Nothing
+
+{- | Open a new proposal in the registry.
+Mirrors Lean @openProposal@.
+-}
+openProposal
+    :: ProposalRegistry p r
+    -> ProposalId
+    -> p
+    -> MemberId
+    -> Timestamp
+    -> ProposalRegistry p r
+openProposal reg pid content proposer deadline =
+    TrackedProposal
+        { tpProposalId = pid
+        , tpContent = content
+        , tpProposer = proposer
+        , tpDeadline = deadline
+        , tpResponses = []
+        , tpRespondents = []
+        , tpStatus = Open
+        }
+        : reg
+
+{- | Add a response to an open proposal.
+Mirrors Lean @addResponse@.
+-}
+addResponse
+    :: ProposalRegistry p r
+    -> ProposalId
+    -> MemberId
+    -> r
+    -> ProposalRegistry p r
+addResponse reg pid responder response =
+    map
+        ( \tp ->
+            if tpProposalId tp == pid
+                && isOpen (tpStatus tp)
+                then
+                    tp
+                        { tpResponses =
+                            response : tpResponses tp
+                        , tpRespondents =
+                            responder
+                                : tpRespondents tp
+                        }
+                else tp
+        )
+        reg
+
+{- | Resolve a proposal with a given resolution.
+Mirrors Lean @resolveProposal@.
+-}
+resolveProposal
+    :: ProposalRegistry p r
+    -> ProposalId
+    -> Resolution
+    -> ProposalRegistry p r
+resolveProposal reg pid r =
+    map
+        ( \tp ->
+            if tpProposalId tp == pid
+                && isOpen (tpStatus tp)
+                then tp{tpStatus = Resolved r}
+                else tp
+        )
+        reg
+
+{- | A member can only respond once per proposal.
+Mirrors Lean @hasNotResponded@.
+-}
+hasNotResponded
+    :: TrackedProposal p r -> MemberId -> Bool
+hasNotResponded tp m =
+    m `notElem` tpRespondents tp
+
+{- | Only open proposals accept responses, and only
+from members who haven't responded yet.
+Mirrors Lean @canRespond@.
+-}
+canRespond
+    :: TrackedProposal p r -> MemberId -> Bool
+canRespond tp m =
+    isOpen (tpStatus tp) && hasNotResponded tp m

--- a/lib/KelCircle/Sequence.hs
+++ b/lib/KelCircle/Sequence.hs
@@ -1,0 +1,81 @@
+{- |
+Module      : KelCircle.Sequence
+Description : Global sequence and sequenced events
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+The global sequence: a monotonic counter managed by the
+sequencer. Each event gets a unique index and a strictly
+increasing UTC timestamp. Mirrors Lean
+@KelCircle.GlobalSequence@.
+-}
+module KelCircle.Sequence
+    ( -- * Sequenced events
+      SequencedEvent (..)
+
+      -- * Invariant checks
+    , indicesContiguous
+    , timestampsIncreasing
+    , noDuplicateIndices
+    , isWellFormed
+    ) where
+
+import Data.List (nub)
+import KelCircle.Types (MemberId, Timestamp)
+
+{- | A sequenced event: an interaction event assigned a
+position in the global sequence by the sequencer.
+Mirrors Lean @SequencedEvent@.
+-}
+data SequencedEvent a = SequencedEvent
+    { seqIndex :: Int
+    -- ^ Position in the global sequence
+    , seqTimestamp :: Timestamp
+    -- ^ UTC timestamp assigned by sequencer
+    , seqMember :: MemberId
+    -- ^ Member who submitted the event
+    , seqPayload :: a
+    -- ^ Event content
+    }
+    deriving stock (Show)
+
+{- | Check that indices form a contiguous range @[0, n)@.
+Events are stored newest-first (head = most recent).
+Mirrors Lean @indicesContiguous@.
+-}
+indicesContiguous :: [SequencedEvent a] -> Bool
+indicesContiguous = go
+  where
+    go [] = True
+    go (e : rest) =
+        seqIndex e == length rest && go rest
+
+{- | Check that timestamps strictly increase (newest
+first in list).
+Mirrors Lean @timestampsIncreasing@.
+-}
+timestampsIncreasing :: [SequencedEvent a] -> Bool
+timestampsIncreasing = go
+  where
+    go [] = True
+    go [_] = True
+    go (e1 : e2 : rest) =
+        seqTimestamp e1 > seqTimestamp e2
+            && go (e2 : rest)
+
+{- | Check that no two events share the same index.
+Mirrors Lean @noDuplicateIndices@.
+-}
+noDuplicateIndices :: [SequencedEvent a] -> Bool
+noDuplicateIndices es =
+    let indices = map seqIndex es
+    in  indices == nub indices
+
+{- | A well-formed sequence satisfies all three invariants.
+Mirrors Lean @WellFormedSequence@.
+-}
+isWellFormed :: [SequencedEvent a] -> Bool
+isWellFormed gs =
+    indicesContiguous gs
+        && timestampsIncreasing gs
+        && noDuplicateIndices gs

--- a/lib/KelCircle/State.hs
+++ b/lib/KelCircle/State.hs
@@ -1,0 +1,166 @@
+{- |
+Module      : KelCircle.State
+Description : Circle state and membership queries
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Circle state derived by folding the global sequence.
+Membership and admin queries, bootstrap mode detection.
+Mirrors Lean @KelCircle.Invariants@ and
+@KelCircle.BaseDecisions@.
+-}
+module KelCircle.State
+    ( -- * Circle state
+      CircleState (..)
+    , Circle (..)
+    , emptyCircle
+
+      -- * Membership queries
+    , isMember
+    , isAdmin
+    , adminCount
+    , majority
+
+      -- * Bootstrap mode
+    , AuthMode (..)
+    , authMode
+    , isBootstrap
+
+      -- * State transitions
+    , applyBaseDecision
+    ) where
+
+import KelCircle.Events (BaseDecision (..))
+import KelCircle.Types
+    ( Member (..)
+    , MemberId
+    , Role (..)
+    )
+
+{- | The circle's membership state.
+Mirrors Lean @CircleState@.
+-}
+newtype CircleState = CircleState
+    { members :: [Member]
+    }
+    deriving stock (Show, Eq)
+
+{- | Full circle state: members + current sequencer.
+Mirrors Lean @Circle@.
+-}
+data Circle = Circle
+    { circleState :: CircleState
+    -- ^ Current membership
+    , sequencerId :: MemberId
+    -- ^ Identity of the sequencer
+    }
+    deriving stock (Show, Eq)
+
+{- | Empty circle with no members.
+Mirrors Lean @emptyCircle@.
+-}
+emptyCircle :: CircleState
+emptyCircle = CircleState []
+
+{- | Is the given member in the circle?
+Mirrors Lean @isMemberB@.
+-}
+isMember :: CircleState -> MemberId -> Bool
+isMember s m = any (\mem -> memberId mem == m) (members s)
+
+{- | Is the given member an admin?
+Mirrors Lean @isAdminB@.
+-}
+isAdmin :: CircleState -> MemberId -> Bool
+isAdmin s m =
+    any
+        ( \mem ->
+            memberId mem == m
+                && memberRole mem == Admin
+        )
+        (members s)
+
+{- | Count the admins in the circle.
+Mirrors Lean @adminCount@.
+-}
+adminCount :: CircleState -> Int
+adminCount s =
+    length $ filter (\m -> memberRole m == Admin) (members s)
+
+{- | Majority threshold: strictly more than half.
+Mirrors Lean @majority@.
+-}
+majority :: Int -> Int
+majority n = n `div` 2 + 1
+
+-- | Authentication mode.
+data AuthMode
+    = -- | Zero admins: passphrase-based auth
+      Bootstrap
+    | -- | Normal operation with admin gating
+      Normal
+    deriving stock (Eq, Show)
+
+{- | Determine the current authentication mode.
+Mirrors Lean @isBootstrapB@.
+-}
+authMode :: CircleState -> AuthMode
+authMode s
+    | adminCount s == 0 = Bootstrap
+    | otherwise = Normal
+
+-- | Is the circle in bootstrap mode?
+isBootstrap :: CircleState -> Bool
+isBootstrap s = authMode s == Bootstrap
+
+{- | Apply a base decision to the circle.
+Mirrors Lean @applyBaseDecision@.
+-}
+applyBaseDecision :: Circle -> BaseDecision -> Circle
+applyBaseDecision c = \case
+    IntroduceMember mid role ->
+        c
+            { circleState =
+                (circleState c)
+                    { members =
+                        MemberRecord mid role
+                            : members (circleState c)
+                    }
+            }
+    RemoveMember mid ->
+        c
+            { circleState =
+                (circleState c)
+                    { members =
+                        filter
+                            (\m -> memberId m /= mid)
+                            (members (circleState c))
+                    }
+            }
+    ChangeRole mid newRole ->
+        c
+            { circleState =
+                (circleState c)
+                    { members =
+                        map
+                            ( \m ->
+                                if memberId m == mid
+                                    then
+                                        MemberRecord
+                                            mid
+                                            newRole
+                                    else m
+                            )
+                            (members (circleState c))
+                    }
+            }
+    RotateSequencer newSid ->
+        Circle
+            { circleState =
+                (circleState c)
+                    { members =
+                        MemberRecord newSid Member
+                            : members (circleState c)
+                    }
+            , sequencerId = newSid
+            }

--- a/lib/KelCircle/Types.hs
+++ b/lib/KelCircle/Types.hs
@@ -1,0 +1,62 @@
+{- |
+Module      : KelCircle.Types
+Description : Core types for the kel-circle protocol
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Base types mirroring the Lean formalization in
+@KelCircle.GlobalSequence@ and @KelCircle.Events@:
+member identifiers, timestamps, roles, and members.
+-}
+module KelCircle.Types
+    ( -- * Identifiers
+      MemberId (..)
+    , ProposalId
+    , Timestamp
+
+      -- * Roles and members
+    , Role (..)
+    , Member (..)
+    ) where
+
+import Data.Text (Text)
+
+{- | A member identifier (KERI prefix).
+Mirrors Lean @MemberId@.
+-}
+newtype MemberId = MemberId {unMemberId :: Text}
+    deriving stock (Show)
+    deriving newtype (Eq, Ord)
+
+{- | A proposal identifier: the sequence index where
+the proposal was opened.
+Mirrors Lean @ProposalId@.
+-}
+type ProposalId = Int
+
+{- | UTC timestamp (milliseconds since epoch).
+Mirrors Lean @Timestamp@ (abstract, monotonically
+increasing).
+-}
+type Timestamp = Int
+
+{- | Role in the circle.
+Mirrors Lean @Role@.
+-}
+data Role
+    = -- | Can manage membership and approve proposals
+      Admin
+    | -- | Regular circle participant
+      Member
+    deriving stock (Eq, Ord, Show)
+
+{- | A circle member with their identifier and role.
+Mirrors Lean @Member@.
+-}
+data Member = MemberRecord
+    { memberId :: MemberId
+    -- ^ KERI prefix
+    , memberRole :: Role
+    -- ^ Current role
+    }
+    deriving stock (Eq, Show)


### PR DESCRIPTION
## Summary

- 8 new Haskell modules under `lib/KelCircle/` mirroring the Lean formalization: Types, Sequence, Events, Fold, State, Gate, Proposals, Processing
- Every Haskell function cross-references its Lean counterpart in Haddock
- Pure types and functions only — no IO, no dependencies beyond `base` and `text`
- CI recipe updated: now runs format-check, hlint, cabal build, lean, and docs

## Test plan

- [x] `cabal build all -O0` compiles with no warnings (GHC 9.8.4, `-Werror`)
- [x] `hlint lib/` — no hints
- [x] `fourmolu --mode check` — all files formatted
- [x] `just ci` passes locally (format, lint, build, lean, docs)