### PR TITLE
feat: validation and QuickCheck tests mirroring Lean

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,11 +8,11 @@ test:
 
 # Format Haskell sources
 format:
-    fourmolu -i lib/**/*.hs lib/KelCircle.hs
+    fourmolu -i lib/**/*.hs lib/KelCircle.hs test/Main.hs test/KelCircle/Test/*.hs
 
 # Lint Haskell sources
 lint:
-    hlint lib/
+    hlint lib/ test/
 
 # Format cabal file
 cabal-fmt:
@@ -43,11 +43,11 @@ test-client:
     cd client && spago test -p kel-circle-client
 
 # Full CI check
-ci: format-check lint build lean build-docs
+ci: format-check lint build test lean build-docs
 
 # Check Haskell formatting (no modification)
 format-check:
-    fourmolu --mode check lib/**/*.hs lib/KelCircle.hs
+    fourmolu --mode check lib/**/*.hs lib/KelCircle.hs test/Main.hs test/KelCircle/Test/*.hs
 
 # Build documentation
 build-docs:

--- a/kel-circle.cabal
+++ b/kel-circle.cabal
@@ -34,6 +34,12 @@ common opts-lib
     -Wmissing-export-lists -Wname-shadowing
     -Wredundant-constraints
 
+common opts-test
+  ghc-options:
+    -Wall -Werror -Wunused-imports -Wunused-packages
+    -Wname-shadowing -Wredundant-constraints
+    -threaded -rtsopts -with-rtsopts=-N
+
 library
   import:          language, opts-lib
   hs-source-dirs:  lib
@@ -47,6 +53,28 @@ library
     KelCircle.Sequence
     KelCircle.State
     KelCircle.Types
+    KelCircle.Validate
   build-depends:
     , base  >=4.18 && <5
     , text  >=2.0  && <3
+
+test-suite unit-tests
+  import:         language, opts-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        Main.hs
+  other-modules:
+    KelCircle.Test.BaseDecisions
+    KelCircle.Test.Gate
+    KelCircle.Test.Generators
+    KelCircle.Test.Processing
+    KelCircle.Test.Proposals
+    KelCircle.Test.Sequence
+  build-depends:
+    , base           >=4.18 && <5
+    , kel-circle
+    , QuickCheck     >=2.14 && <3
+    , tasty          >=1.4  && <2
+    , tasty-hunit    >=0.10 && <1
+    , tasty-quickcheck >=0.10 && <1
+    , text           >=2.0  && <3

--- a/lib/KelCircle.hs
+++ b/lib/KelCircle.hs
@@ -31,6 +31,9 @@ module KelCircle
 
       -- * Event processing pipeline
     , module KelCircle.Processing
+
+      -- * Validation
+    , module KelCircle.Validate
     ) where
 
 import KelCircle.Events
@@ -41,3 +44,4 @@ import KelCircle.Proposals
 import KelCircle.Sequence
 import KelCircle.State
 import KelCircle.Types
+import KelCircle.Validate

--- a/lib/KelCircle/Validate.hs
+++ b/lib/KelCircle/Validate.hs
@@ -1,0 +1,105 @@
+{- |
+Module      : KelCircle.Validate
+Description : Event validation and error reporting
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Validation functions that combine the gate checks with
+error reporting. Each validation function returns either
+@Right ()@ or @Left ValidationError@.
+-}
+module KelCircle.Validate
+    ( -- * Validation errors
+      ValidationError (..)
+
+      -- * Event validation
+    , validateBaseDecision
+    , validateAppDecision
+    , validateProposal
+    , validateResponse
+    , validateResolve
+    ) where
+
+import KelCircle.Events (BaseDecision)
+import KelCircle.Processing
+    ( FullState (..)
+    , gateAppDecision
+    , gateBaseDecision
+    , gateProposal
+    , gateResolve
+    , gateResponse
+    )
+import KelCircle.Types
+    ( MemberId
+    , ProposalId
+    )
+
+-- | Validation errors for event submission.
+data ValidationError
+    = -- | Base gate rejected the decision
+      BaseGateRejected BaseDecision
+    | -- | App gate rejected a decision
+      AppGateRejected
+    | -- | Proposal gate rejected
+      ProposalGateRejected
+    | {- | Response gate rejected (not member,
+      already responded, or proposal not open)
+      -}
+      ResponseGateRejected ProposalId
+    | -- | Only the sequencer can resolve proposals
+      NotSequencer MemberId
+    deriving stock (Show, Eq)
+
+-- | Validate a base decision submission.
+validateBaseDecision
+    :: FullState g p r
+    -> MemberId
+    -> BaseDecision
+    -> (g -> BaseDecision -> Bool)
+    -> Either ValidationError ()
+validateBaseDecision s signer d appGate
+    | gateBaseDecision s signer d appGate = Right ()
+    | otherwise = Left (BaseGateRejected d)
+
+-- | Validate an application decision submission.
+validateAppDecision
+    :: FullState g p r
+    -> MemberId
+    -> d
+    -> (g -> d -> Bool)
+    -> Either ValidationError ()
+validateAppDecision s signer content appGate
+    | gateAppDecision s signer content appGate =
+        Right ()
+    | otherwise = Left AppGateRejected
+
+-- | Validate a proposal submission.
+validateProposal
+    :: FullState g p r
+    -> MemberId
+    -> p
+    -> (g -> p -> Bool)
+    -> Either ValidationError ()
+validateProposal s signer content appGate
+    | gateProposal s signer content appGate =
+        Right ()
+    | otherwise = Left ProposalGateRejected
+
+-- | Validate a response submission.
+validateResponse
+    :: FullState g p r
+    -> MemberId
+    -> ProposalId
+    -> Either ValidationError ()
+validateResponse s signer pid
+    | gateResponse s signer pid = Right ()
+    | otherwise = Left (ResponseGateRejected pid)
+
+-- | Validate a proposal resolution.
+validateResolve
+    :: FullState g p r
+    -> MemberId
+    -> Either ValidationError ()
+validateResolve s signer
+    | gateResolve s signer = Right ()
+    | otherwise = Left (NotSequencer signer)

--- a/test/KelCircle/Test/BaseDecisions.hs
+++ b/test/KelCircle/Test/BaseDecisions.hs
@@ -1,0 +1,214 @@
+{- |
+Module      : KelCircle.Test.BaseDecisions
+Description : Properties for base decisions and genesis
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+QuickCheck properties mirroring the Lean theorems in
+@KelCircle.BaseDecisions@: genesis, introduction, admin
+exits bootstrap, sequencer protection, demotion.
+-}
+module KelCircle.Test.BaseDecisions
+    ( tests
+    ) where
+
+import KelCircle.Events (BaseDecision (..))
+import KelCircle.Gate (baseGate)
+import KelCircle.Processing
+    ( FullState (..)
+    , applyBase
+    , initFullState
+    )
+import KelCircle.State
+    ( Circle (..)
+    , applyBaseDecision
+    , emptyCircle
+    , isAdmin
+    , isBootstrap
+    , isMember
+    )
+import KelCircle.Test.Generators ()
+import KelCircle.Types (MemberId (..), Role (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+    ( assertBool
+    , testCase
+    )
+import Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests =
+    testGroup
+        "BaseDecisions"
+        [ testGenesis
+        , testIntroduction
+        , testBootstrapExit
+        , testSequencerProtection
+        , testDemotion
+        ]
+
+-- Genesis helpers
+sid :: MemberId
+sid = MemberId "sequencer-0"
+
+aid :: MemberId
+aid = MemberId "admin-0"
+
+genesisCircle :: Circle
+genesisCircle =
+    applyBaseDecision
+        ( Circle
+            { circleState = emptyCircle
+            , sequencerId = sid
+            }
+        )
+        (IntroduceMember sid Member)
+
+-- ---------------------------------------------------------
+-- Genesis (mirrors Lean genesis_* theorems)
+-- ---------------------------------------------------------
+
+testGenesis :: TestTree
+testGenesis =
+    testGroup
+        "genesis"
+        [ testCase
+            "sequencer is member after genesis"
+            $ assertBool "" (isMember (circleState genesisCircle) sid)
+        , testCase
+            "sequencer is NOT admin after genesis"
+            $ assertBool
+                ""
+                (not $ isAdmin (circleState genesisCircle) sid)
+        , testCase
+            "circle is in bootstrap after genesis"
+            $ assertBool
+                ""
+                (isBootstrap (circleState genesisCircle))
+        , testCase
+            "sequencer id preserved"
+            $ assertBool
+                ""
+                (sequencerId genesisCircle == sid)
+        ]
+
+-- ---------------------------------------------------------
+-- Introduction (mirrors introduce_* theorems)
+-- ---------------------------------------------------------
+
+testIntroduction :: TestTree
+testIntroduction =
+    testGroup
+        "introduce"
+        [ testProperty
+            "introduces member to circle"
+            $ \mid' ->
+                let c' =
+                        applyBaseDecision
+                            genesisCircle
+                            (IntroduceMember mid' Member)
+                in  isMember (circleState c') mid'
+        , testProperty
+            "preserves existing members"
+            $ \mid' ->
+                let c' =
+                        applyBaseDecision
+                            genesisCircle
+                            (IntroduceMember mid' Member)
+                in  isMember (circleState c') sid
+        ]
+
+-- ---------------------------------------------------------
+-- Bootstrap exit (mirrors introduce_admin_exits_bootstrap)
+-- ---------------------------------------------------------
+
+testBootstrapExit :: TestTree
+testBootstrapExit =
+    testGroup
+        "bootstrap exit"
+        [ testProperty
+            "introducing admin exits bootstrap"
+            $ \mid' ->
+                let c' =
+                        applyBaseDecision
+                            genesisCircle
+                            (IntroduceMember mid' Admin)
+                in  not (isBootstrap (circleState c'))
+        ]
+
+-- ---------------------------------------------------------
+-- Sequencer protection (mirrors sequencer_removal_rejected,
+-- sequencer_admin_promotion_rejected)
+-- ---------------------------------------------------------
+
+testSequencerProtection :: TestTree
+testSequencerProtection =
+    testGroup
+        "sequencer protection"
+        [ testCase
+            "sequencer removal is always rejected by base gate"
+            $ do
+                let s0 = initFullState sid ()
+                    s1 = applyBase s0 (IntroduceMember aid Admin)
+                -- After exiting bootstrap, try to remove sequencer
+                -- The base gate should reject this
+                let gateResult =
+                        baseGate
+                            (circleState (fsCircle s1))
+                            aid
+                            sid
+                            (RemoveMember sid)
+                assertBool "should reject" (not gateResult)
+        , testCase
+            "sequencer promotion to admin is rejected"
+            $ do
+                let s0 = initFullState sid ()
+                    s1 = applyBase s0 (IntroduceMember aid Admin)
+                let gateResult =
+                        baseGate
+                            (circleState (fsCircle s1))
+                            aid
+                            sid
+                            (ChangeRole sid Admin)
+                assertBool "should reject" (not gateResult)
+        ]
+
+-- ---------------------------------------------------------
+-- Demotion (mirrors demote_sole_admin_enters_bootstrap)
+-- ---------------------------------------------------------
+
+testDemotion :: TestTree
+testDemotion =
+    testGroup
+        "demotion"
+        [ testCase
+            "demoting sole admin re-enters bootstrap"
+            $ do
+                let c0 = genesisCircle
+                    c1 =
+                        applyBaseDecision
+                            c0
+                            (IntroduceMember aid Admin)
+                    c2 =
+                        applyBaseDecision
+                            c1
+                            (ChangeRole aid Member)
+                assertBool
+                    "should be bootstrap"
+                    (isBootstrap (circleState c2))
+        , testCase
+            "sequencer survives demotion"
+            $ do
+                let c0 = genesisCircle
+                    c1 =
+                        applyBaseDecision
+                            c0
+                            (IntroduceMember aid Admin)
+                    c2 =
+                        applyBaseDecision
+                            c1
+                            (ChangeRole aid Member)
+                assertBool
+                    "sequencer still member"
+                    (isMember (circleState c2) sid)
+        ]

--- a/test/KelCircle/Test/Gate.hs
+++ b/test/KelCircle/Test/Gate.hs
@@ -1,0 +1,192 @@
+{- |
+Module      : KelCircle.Test.Gate
+Description : Properties for the two-level gate
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+QuickCheck properties mirroring the Lean theorems in
+@KelCircle.BaseDecisions@ (gate section): bootstrap gate
+behavior, full gate composition, admin majority.
+-}
+module KelCircle.Test.Gate
+    ( tests
+    ) where
+
+import KelCircle.Events (BaseDecision (..))
+import KelCircle.Gate
+    ( baseGate
+    , fullGate
+    , hasAdminMajority
+    )
+import KelCircle.Processing
+    ( FullState (..)
+    , applyBase
+    , initFullState
+    )
+import KelCircle.State
+    ( Circle (..)
+    , CircleState
+    , majority
+    )
+import KelCircle.Test.Generators ()
+import KelCircle.Types (MemberId (..), Role (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+    ( assertBool
+    , assertEqual
+    , testCase
+    )
+import Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests =
+    testGroup
+        "Gate"
+        [ testBootstrapGate
+        , testFullGateComposition
+        , testAdminMajority
+        , testRotationGate
+        ]
+
+sid :: MemberId
+sid = MemberId "sequencer-0"
+
+aid :: MemberId
+aid = MemberId "admin-0"
+
+bootstrapState :: CircleState
+bootstrapState =
+    circleState
+        (fsCircle (initFullState sid () :: FullState () () ()))
+
+normalState :: FullState () () ()
+normalState =
+    let s0 = initFullState sid ()
+    in  applyBase s0 (IntroduceMember aid Admin)
+
+-- ---------------------------------------------------------
+-- Bootstrap gate (mirrors bootstrap_accepts_admin_intro,
+-- bootstrap_rejects_member_intro, bootstrap_rejects_remove)
+-- ---------------------------------------------------------
+
+testBootstrapGate :: TestTree
+testBootstrapGate =
+    testGroup
+        "bootstrap"
+        [ testProperty
+            "accepts admin introduction"
+            $ \mid' ->
+                baseGate
+                    bootstrapState
+                    sid
+                    sid
+                    (IntroduceMember mid' Admin)
+        , testProperty
+            "rejects member introduction"
+            $ \mid' ->
+                not $
+                    baseGate
+                        bootstrapState
+                        sid
+                        sid
+                        (IntroduceMember mid' Member)
+        , testCase
+            "rejects removal"
+            $ assertBool ""
+            $ not
+            $ baseGate
+                bootstrapState
+                sid
+                sid
+                (RemoveMember aid)
+        ]
+
+-- ---------------------------------------------------------
+-- Full gate composition (mirrors full_gate_base_rejects,
+-- full_gate_app_rejects)
+-- ---------------------------------------------------------
+
+testFullGateComposition :: TestTree
+testFullGateComposition =
+    testGroup
+        "full gate"
+        [ testCase
+            "base rejection overrides app gate"
+            $ do
+                let s = circleState (fsCircle normalState)
+                    -- RemoveMember of sequencer: base gate rejects
+                    result =
+                        fullGate
+                            s
+                            aid
+                            sid
+                            (RemoveMember sid)
+                            ()
+                            (\_ _ -> True)
+                assertBool
+                    "should reject"
+                    (not result)
+        , testCase
+            "app rejection overrides base gate"
+            $ do
+                let s = circleState (fsCircle normalState)
+                    -- valid base gate, but app rejects
+                    result =
+                        fullGate
+                            s
+                            aid
+                            sid
+                            (IntroduceMember (MemberId "new") Member)
+                            ()
+                            (\_ _ -> False)
+                assertBool
+                    "should reject"
+                    (not result)
+        ]
+
+-- ---------------------------------------------------------
+-- Admin majority (mirrors single_admin_majority,
+-- single_admin_majority_self)
+-- ---------------------------------------------------------
+
+testAdminMajority :: TestTree
+testAdminMajority =
+    testGroup
+        "admin majority"
+        [ testCase "majority of 1 is 1" $
+            assertEqual
+                ""
+                1
+                (majority 1)
+        , testCase
+            "single admin meets majority with self"
+            $ do
+                let s = circleState (fsCircle normalState)
+                assertBool "" $
+                    hasAdminMajority s [aid]
+        , testCase
+            "empty respondents don't meet majority"
+            $ do
+                let s = circleState (fsCircle normalState)
+                assertBool "" $
+                    not (hasAdminMajority s [])
+        ]
+
+-- ---------------------------------------------------------
+-- Rotation gate (mirrors rotate_accepted_by_admin)
+-- ---------------------------------------------------------
+
+testRotationGate :: TestTree
+testRotationGate =
+    testGroup
+        "rotation"
+        [ testProperty
+            "admin can rotate sequencer"
+            $ \newSid ->
+                let s = circleState (fsCircle normalState)
+                in  baseGate
+                        s
+                        aid
+                        sid
+                        (RotateSequencer newSid)
+        ]

--- a/test/KelCircle/Test/Generators.hs
+++ b/test/KelCircle/Test/Generators.hs
@@ -1,0 +1,130 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- |
+Module      : KelCircle.Test.Generators
+Description : QuickCheck generators for protocol types
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Arbitrary instances and generators for all kel-circle
+types. Used by property tests that mirror Lean theorems.
+-}
+module KelCircle.Test.Generators
+    ( -- * Re-exports for convenience
+      module Test.QuickCheck
+
+      -- * Generators
+    , genMemberId
+    , genDistinctMemberIds
+    , genRole
+    , genMember
+    , genBaseDecision
+    , genResolution
+    , genCircleWithAdmin
+    , genFullStateBootstrap
+    , genFullStateNormal
+    ) where
+
+import Data.Text (pack)
+import KelCircle.Events
+    ( BaseDecision (..)
+    , Resolution (..)
+    )
+import KelCircle.Processing
+    ( FullState (..)
+    , applyBase
+    , initFullState
+    )
+import KelCircle.Types
+    ( Member (..)
+    , MemberId (..)
+    , Role (..)
+    )
+import Test.QuickCheck
+
+-- | Generate a member identifier.
+genMemberId :: Gen MemberId
+genMemberId =
+    MemberId . pack . ("member-" <>)
+        <$> elements
+            (map show [0 :: Int .. 9])
+
+-- | Generate n distinct member identifiers.
+genDistinctMemberIds :: Int -> Gen [MemberId]
+genDistinctMemberIds n = do
+    let ids =
+            map
+                ( MemberId
+                    . pack
+                    . ("member-" <>)
+                    . show
+                )
+                [0 :: Int .. n - 1]
+    pure ids
+
+-- | Generate a role.
+genRole :: Gen Role
+genRole = elements [Admin, Member]
+
+-- | Generate a member record.
+genMember :: Gen Member
+genMember =
+    MemberRecord
+        <$> genMemberId
+        <*> genRole
+
+-- | Generate a base decision.
+genBaseDecision :: Gen BaseDecision
+genBaseDecision =
+    oneof
+        [ IntroduceMember <$> genMemberId <*> genRole
+        , RemoveMember <$> genMemberId
+        , ChangeRole <$> genMemberId <*> genRole
+        , RotateSequencer <$> genMemberId
+        ]
+
+-- | Generate a resolution.
+genResolution :: Gen Resolution
+genResolution =
+    elements
+        [ ThresholdReached
+        , ProposerPositive
+        , ProposerNegative
+        , Timeout
+        ]
+
+instance Arbitrary MemberId where
+    arbitrary = genMemberId
+
+instance Arbitrary Role where
+    arbitrary = genRole
+
+instance Arbitrary Member where
+    arbitrary = genMember
+
+instance Arbitrary BaseDecision where
+    arbitrary = genBaseDecision
+
+instance Arbitrary Resolution where
+    arbitrary = genResolution
+
+{- | Generate a circle that has exited bootstrap mode
+(has at least one admin).
+-}
+genCircleWithAdmin :: Gen (FullState () () ())
+genCircleWithAdmin = do
+    sid <- genMemberId
+    aid <- genMemberId
+    let s0 = initFullState sid ()
+        s1 = applyBase s0 (IntroduceMember aid Admin)
+    pure s1
+
+-- | Generate a FullState in bootstrap mode (no admins).
+genFullStateBootstrap :: Gen (FullState () () ())
+genFullStateBootstrap = do
+    sid <- genMemberId
+    pure (initFullState sid ())
+
+-- | Generate a FullState with one admin (normal mode).
+genFullStateNormal :: Gen (FullState () () ())
+genFullStateNormal = genCircleWithAdmin

--- a/test/KelCircle/Test/Processing.hs
+++ b/test/KelCircle/Test/Processing.hs
@@ -1,0 +1,250 @@
+{- |
+Module      : KelCircle.Test.Processing
+Description : Properties for event processing pipeline
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+QuickCheck properties mirroring the Lean theorems in
+@KelCircle.Processing@: sequence number increments,
+circle preservation, proposal registry preservation,
+gate/sequencer interaction.
+-}
+module KelCircle.Test.Processing
+    ( tests
+    ) where
+
+import KelCircle.Events
+    ( BaseDecision (..)
+    , Resolution (..)
+    )
+import KelCircle.Processing
+    ( FullState (..)
+    , applyAppDecision
+    , applyBase
+    , applyProposal
+    , applyResolve
+    , applyResponse
+    , gateResolve
+    , initFullState
+    )
+import KelCircle.State (Circle (..), isMember)
+import KelCircle.Test.Generators ()
+import KelCircle.Types (MemberId (..), Role (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+    ( assertBool
+    , assertEqual
+    , testCase
+    )
+import Test.Tasty.QuickCheck (testProperty, (==>))
+
+tests :: TestTree
+tests =
+    testGroup
+        "Processing"
+        [ testSeqIncrements
+        , testCirclePreservation
+        , testProposalPreservation
+        , testGateSequencer
+        , testGenesisState
+        ]
+
+sid :: MemberId
+sid = MemberId "sequencer-0"
+
+aid :: MemberId
+aid = MemberId "admin-0"
+
+s0 :: FullState () () ()
+s0 = initFullState sid ()
+
+s1 :: FullState () () ()
+s1 = applyBase s0 (IntroduceMember aid Admin)
+
+-- ---------------------------------------------------------
+-- Sequence increments (mirrors apply_*_increments_seq)
+-- ---------------------------------------------------------
+
+testSeqIncrements :: TestTree
+testSeqIncrements =
+    testGroup
+        "sequence increments"
+        [ testCase "base increments" $
+            assertEqual
+                ""
+                (fsNextSeq s0 + 1)
+                ( fsNextSeq $
+                    applyBase
+                        s0
+                        (IntroduceMember aid Admin)
+                )
+        , testCase "app decision increments" $
+            assertEqual
+                ""
+                (fsNextSeq s1 + 1)
+                ( fsNextSeq $
+                    applyAppDecision
+                        s1
+                        ()
+                        (\_ _ -> ())
+                )
+        , testCase "proposal increments" $
+            assertEqual
+                ""
+                (fsNextSeq s1 + 1)
+                ( fsNextSeq $
+                    applyProposal
+                        s1
+                        ()
+                        aid
+                        1000
+                )
+        , testCase "response increments" $
+            assertEqual
+                ""
+                (fsNextSeq s1 + 1)
+                ( fsNextSeq $
+                    applyResponse
+                        s1
+                        ()
+                        aid
+                        0
+                )
+        , testCase "resolve increments" $
+            assertEqual
+                ""
+                (fsNextSeq s1 + 1)
+                ( fsNextSeq $
+                    applyResolve
+                        s1
+                        0
+                        ThresholdReached
+                )
+        ]
+
+-- ---------------------------------------------------------
+-- Circle preservation (mirrors
+-- app_decision_preserves_circle, proposal_preserves_circle,
+-- response_preserves_circle, resolve_preserves_circle)
+-- ---------------------------------------------------------
+
+testCirclePreservation :: TestTree
+testCirclePreservation =
+    testGroup
+        "circle preservation"
+        [ testCase "app decision preserves circle" $
+            assertEqual
+                ""
+                (fsCircle s1)
+                ( fsCircle $
+                    applyAppDecision
+                        s1
+                        ()
+                        (\_ _ -> ())
+                )
+        , testCase "proposal preserves circle" $
+            assertEqual
+                ""
+                (fsCircle s1)
+                ( fsCircle $
+                    applyProposal
+                        s1
+                        ()
+                        aid
+                        1000
+                )
+        , testCase "response preserves circle" $
+            assertEqual
+                ""
+                (fsCircle s1)
+                ( fsCircle $
+                    applyResponse
+                        s1
+                        ()
+                        aid
+                        0
+                )
+        , testCase "resolve preserves circle" $
+            assertEqual
+                ""
+                (fsCircle s1)
+                ( fsCircle $
+                    applyResolve
+                        s1
+                        0
+                        ThresholdReached
+                )
+        ]
+
+-- ---------------------------------------------------------
+-- Proposal registry preservation (mirrors
+-- base_preserves_proposals,
+-- app_decision_preserves_proposals)
+-- ---------------------------------------------------------
+
+testProposalPreservation :: TestTree
+testProposalPreservation =
+    testGroup
+        "proposal preservation"
+        [ testCase "base preserves proposals" $
+            assertEqual
+                ""
+                (fsProposals s1)
+                ( fsProposals $
+                    applyBase
+                        s1
+                        (IntroduceMember (MemberId "new") Member)
+                )
+        , testCase "app decision preserves proposals" $
+            assertEqual
+                ""
+                (fsProposals s1)
+                ( fsProposals $
+                    applyAppDecision
+                        s1
+                        ()
+                        (\_ _ -> ())
+                )
+        ]
+
+-- ---------------------------------------------------------
+-- Gate/sequencer interaction (mirrors
+-- non_sequencer_cannot_resolve, sequencer_can_resolve)
+-- ---------------------------------------------------------
+
+testGateSequencer :: TestTree
+testGateSequencer =
+    testGroup
+        "gate/sequencer"
+        [ testProperty
+            "non-sequencer cannot resolve"
+            $ \signer ->
+                signer /= sid ==>
+                    not (gateResolve s1 signer)
+        , testCase "sequencer can resolve" $
+            assertBool
+                ""
+                (gateResolve s1 sid)
+        ]
+
+-- ---------------------------------------------------------
+-- Genesis state (mirrors init_seq_is_one,
+-- init_no_proposals, init_sequencer_is_member)
+-- ---------------------------------------------------------
+
+testGenesisState :: TestTree
+testGenesisState =
+    testGroup
+        "genesis state"
+        [ testCase "initial seq is 1" $
+            assertEqual "" 1 (fsNextSeq s0)
+        , testCase "initial has no proposals" $
+            assertEqual "" [] (fsProposals s0)
+        , testProperty
+            "initial sequencer is member"
+            $ \sid' ->
+                let s = initFullState sid' () :: FullState () () ()
+                in  isMember
+                        (circleState (fsCircle s))
+                        sid'
+        ]

--- a/test/KelCircle/Test/Proposals.hs
+++ b/test/KelCircle/Test/Proposals.hs
@@ -1,0 +1,207 @@
+{- |
+Module      : KelCircle.Test.Proposals
+Description : Properties for proposal lifecycle
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+QuickCheck properties mirroring the Lean theorems in
+@KelCircle.Proposals@: open, respond, resolve, timeout
+obligation, resolution dichotomy.
+-}
+module KelCircle.Test.Proposals
+    ( tests
+    ) where
+
+import KelCircle.Events
+    ( Resolution (..)
+    , isPositive
+    )
+import KelCircle.Proposals
+    ( ProposalStatus (..)
+    , TrackedProposal (..)
+    , addResponse
+    , canRespond
+    , findProposal
+    , isOpen
+    , openProposal
+    , resolveProposal
+    )
+import KelCircle.Test.Generators ()
+import KelCircle.Types (MemberId (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+    ( assertBool
+    , assertEqual
+    , testCase
+    )
+import Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests =
+    testGroup
+        "Proposals"
+        [ testOpenProposal
+        , testResolve
+        , testResolution
+        , testResponseValidation
+        ]
+
+proposer :: MemberId
+proposer = MemberId "proposer-0"
+
+-- ---------------------------------------------------------
+-- Open proposal (mirrors open_proposal_is_open,
+-- open_proposal_no_responses)
+-- ---------------------------------------------------------
+
+testOpenProposal :: TestTree
+testOpenProposal =
+    testGroup
+        "open"
+        [ testCase "newly opened proposal is open" $
+            do
+                let reg = openProposal [] 0 () proposer 1000
+                case reg of
+                    (tp : _) ->
+                        assertBool "" (isOpen (tpStatus tp))
+                    [] -> assertBool "should have proposal" False
+        , testCase "newly opened has no responses" $
+            do
+                let reg = openProposal [] 0 () proposer 1000
+                case reg of
+                    (tp : _) ->
+                        assertEqual "" 0 (length (tpResponses tp))
+                    [] -> assertBool "should have proposal" False
+        ]
+
+-- ---------------------------------------------------------
+-- Resolve (mirrors resolve_resolved_noop,
+-- resolved_satisfies_obligation)
+-- ---------------------------------------------------------
+
+testResolve :: TestTree
+testResolve =
+    testGroup
+        "resolve"
+        [ testCase "resolving already-resolved is noop" $
+            do
+                let reg0 = openProposal [] 0 () proposer 1000
+                    reg1 =
+                        resolveProposal
+                            reg0
+                            0
+                            ThresholdReached
+                    reg2 = resolveProposal reg1 0 Timeout
+                -- Should still be ThresholdReached, not Timeout
+                case findProposal reg2 0 of
+                    Just tp ->
+                        assertEqual
+                            ""
+                            (Resolved ThresholdReached)
+                            (tpStatus tp)
+                    Nothing ->
+                        assertBool "should find proposal" False
+        , testCase
+            "resolved proposal satisfies timeout obligation"
+            $ do
+                let reg0 = openProposal [] 0 () proposer 1000
+                    reg1 =
+                        resolveProposal
+                            reg0
+                            0
+                            Timeout
+                case findProposal reg1 0 of
+                    Just tp -> do
+                        -- Resolved means isOpen is False
+                        assertBool
+                            "should not be open"
+                            (not $ isOpen (tpStatus tp))
+                    Nothing ->
+                        assertBool "should find proposal" False
+        ]
+
+-- ---------------------------------------------------------
+-- Resolution dichotomy (mirrors resolution_dichotomy,
+-- threshold_is_positive, etc.)
+-- ---------------------------------------------------------
+
+testResolution :: TestTree
+testResolution =
+    testGroup
+        "resolution"
+        [ testProperty
+            "every resolution is positive or negative"
+            $ \r ->
+                isPositive r || not (isPositive r)
+        , testCase "threshold is positive" $
+            assertBool "" (isPositive ThresholdReached)
+        , testCase "proposer-positive is positive" $
+            assertBool "" (isPositive ProposerPositive)
+        , testCase "proposer-negative is negative" $
+            assertBool "" (not $ isPositive ProposerNegative)
+        , testCase "timeout is negative" $
+            assertBool "" (not $ isPositive Timeout)
+        ]
+
+-- ---------------------------------------------------------
+-- Response validation (mirrors
+-- fresh_proposal_accepts_response, canRespond)
+-- ---------------------------------------------------------
+
+testResponseValidation :: TestTree
+testResponseValidation =
+    testGroup
+        "response validation"
+        [ testProperty
+            "fresh proposal accepts any member"
+            $ \m ->
+                let tp =
+                        TrackedProposal
+                            { tpProposalId = 0
+                            , tpContent = ()
+                            , tpProposer = proposer
+                            , tpDeadline = 1000
+                            , tpResponses = [] :: [()]
+                            , tpRespondents = []
+                            , tpStatus = Open
+                            }
+                in  canRespond tp m
+        , testCase
+            "member cannot respond twice"
+            $ do
+                let responder = MemberId "resp-0"
+                    reg0 = openProposal [] 0 () proposer 1000
+                    reg1 =
+                        addResponse
+                            reg0
+                            0
+                            responder
+                            ()
+                case findProposal reg1 0 of
+                    Just tp ->
+                        assertBool
+                            "should not accept second"
+                            (not $ canRespond tp responder)
+                    Nothing ->
+                        assertBool "should find" False
+        , testCase
+            "resolved proposal rejects responses"
+            $ do
+                let reg0 = openProposal [] 0 () proposer 1000
+                    reg1 =
+                        resolveProposal
+                            reg0
+                            0
+                            ThresholdReached
+                case findProposal reg1 0 of
+                    Just tp ->
+                        assertBool
+                            "should reject"
+                            ( not $
+                                canRespond
+                                    tp
+                                    (MemberId "any")
+                            )
+                    Nothing ->
+                        assertBool "should find" False
+        ]

--- a/test/KelCircle/Test/Sequence.hs
+++ b/test/KelCircle/Test/Sequence.hs
@@ -1,0 +1,127 @@
+{- |
+Module      : KelCircle.Test.Sequence
+Description : Properties for global sequence invariants
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+QuickCheck properties mirroring the Lean theorems in
+@KelCircle.GlobalSequence@ and @KelCircle.Invariants@.
+-}
+module KelCircle.Test.Sequence
+    ( tests
+    ) where
+
+import KelCircle.Sequence
+    ( SequencedEvent (..)
+    , indicesContiguous
+    , isWellFormed
+    , noDuplicateIndices
+    , timestampsIncreasing
+    )
+import KelCircle.Test.Generators ()
+import KelCircle.Types (MemberId (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+import Test.Tasty.QuickCheck
+    ( testProperty
+    )
+
+dummyMid :: MemberId
+dummyMid = MemberId "test"
+
+tests :: TestTree
+tests =
+    testGroup
+        "GlobalSequence"
+        [ testEmptyInvariants
+        , testSingletonInvariants
+        , testAppendPreservesContiguous
+        , testAppendPreservesIncreasing
+        , testAppendPreservesNoDups
+        ]
+
+{- | Mirrors: empty_contiguous, empty_increasing,
+empty_no_dups
+-}
+testEmptyInvariants :: TestTree
+testEmptyInvariants =
+    testCase "empty sequence is well-formed" $
+        assertEqual
+            ""
+            True
+            (isWellFormed ([] :: [SequencedEvent ()]))
+
+{- | Mirrors: singleton_contiguous,
+singleton_increasing, singleton_no_dups
+-}
+testSingletonInvariants :: TestTree
+testSingletonInvariants =
+    testCase "singleton with index 0 is well-formed" $
+        let e =
+                SequencedEvent
+                    { seqIndex = 0
+                    , seqTimestamp = 100
+                    , seqMember = dummyMid
+                    , seqPayload = ()
+                    }
+        in  assertEqual "" True (isWellFormed [e])
+
+-- | Mirrors: append_preserves_contiguous
+testAppendPreservesContiguous :: TestTree
+testAppendPreservesContiguous =
+    testProperty
+        "append with correct index preserves contiguity"
+        $ \(ts :: Int) ->
+            let e0 =
+                    SequencedEvent
+                        0
+                        100
+                        dummyMid
+                        ()
+                e1 = SequencedEvent 1 (100 + abs ts + 1) dummyMid ()
+                gs = [e1, e0]
+            in  indicesContiguous gs
+
+-- | Mirrors: append_preserves_increasing
+testAppendPreservesIncreasing :: TestTree
+testAppendPreservesIncreasing =
+    testProperty
+        "append with greater timestamp preserves increasing"
+        $ \(delta :: Int) ->
+            let d = abs delta + 1
+                e0 =
+                    SequencedEvent
+                        0
+                        100
+                        dummyMid
+                        ()
+                e1 =
+                    SequencedEvent
+                        1
+                        (100 + d)
+                        dummyMid
+                        ()
+                gs = [e1, e0]
+            in  timestampsIncreasing gs
+
+-- | Mirrors: append_preserves_no_dups
+testAppendPreservesNoDups :: TestTree
+testAppendPreservesNoDups =
+    testProperty
+        "append with unique index preserves no-dups"
+        $ \(idx :: Int) ->
+            let i = abs idx + 1
+                e0 =
+                    SequencedEvent
+                        0
+                        100
+                        dummyMid
+                        ()
+                e1 =
+                    SequencedEvent
+                        i
+                        200
+                        dummyMid
+                        ()
+                gs = [e1, e0]
+            in  noDuplicateIndices gs

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,29 @@
+{- |
+Module      : Main
+Description : Test entry point
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Runs all property tests mirroring the Lean
+preservation theorems.
+-}
+module Main (main) where
+
+import KelCircle.Test.BaseDecisions qualified
+import KelCircle.Test.Gate qualified
+import KelCircle.Test.Processing qualified
+import KelCircle.Test.Proposals qualified
+import KelCircle.Test.Sequence qualified
+import Test.Tasty (defaultMain, testGroup)
+
+main :: IO ()
+main =
+    defaultMain $
+        testGroup
+            "kel-circle"
+            [ KelCircle.Test.Sequence.tests
+            , KelCircle.Test.BaseDecisions.tests
+            , KelCircle.Test.Gate.tests
+            , KelCircle.Test.Proposals.tests
+            , KelCircle.Test.Processing.tests
+            ]


### PR DESCRIPTION
## Summary

- New `KelCircle.Validate` module with typed validation errors for all event kinds
- 53 QuickCheck property tests mirroring every Lean preservation theorem:
  - GlobalSequence: contiguity, timestamp ordering, no-duplicate indices
  - BaseDecisions: genesis, introduction, bootstrap exit, sequencer protection, demotion
  - Gate: bootstrap gate, full gate composition, admin majority, rotation
  - Proposals: open/resolve lifecycle, resolution dichotomy, response validation
  - Processing: sequence increments, circle preservation, proposal registry preservation, gate/sequencer interaction
- CI recipe updated to include `test` step and lint/format test sources

## Test plan

- [x] `cabal test unit-tests -O0` — 53/53 pass
- [x] `hlint lib/ test/` — no hints
- [x] `fourmolu --mode check` — all files formatted
- [x] `just ci` passes locally (format, lint, build, test, lean, docs)