### PR TITLE
feat: HTTP server, SQLite store, and 15 E2E tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,9 +6,13 @@ build:
 test:
     cabal test all -O0 --test-show-details=direct
 
+# Run E2E tests
+e2e:
+    cabal test e2e-tests -O0 --test-show-details=direct
+
 # Format Haskell sources
 format:
-    fourmolu -i lib/**/*.hs lib/KelCircle.hs test/Main.hs test/KelCircle/Test/*.hs
+    fourmolu -i lib/**/*.hs lib/KelCircle.hs test/Main.hs test/E2EMain.hs test/KelCircle/Test/*.hs test/E2E/*.hs
 
 # Lint Haskell sources
 lint:
@@ -47,7 +51,7 @@ ci: format-check lint build test lean build-docs
 
 # Check Haskell formatting (no modification)
 format-check:
-    fourmolu --mode check lib/**/*.hs lib/KelCircle.hs test/Main.hs test/KelCircle/Test/*.hs
+    fourmolu --mode check lib/**/*.hs lib/KelCircle.hs test/Main.hs test/E2EMain.hs test/KelCircle/Test/*.hs test/E2E/*.hs
 
 # Build documentation
 build-docs:

--- a/kel-circle.cabal
+++ b/kel-circle.cabal
@@ -31,14 +31,12 @@ common language
 common opts-lib
   ghc-options:
     -Wall -Werror -Wunused-imports -Wunused-packages
-    -Wmissing-export-lists -Wname-shadowing
-    -Wredundant-constraints
+    -Wmissing-export-lists -Wname-shadowing -Wredundant-constraints
 
 common opts-test
   ghc-options:
-    -Wall -Werror -Wunused-imports -Wunused-packages
-    -Wname-shadowing -Wredundant-constraints
-    -threaded -rtsopts -with-rtsopts=-N
+    -Wall -Werror -Wunused-imports -Wunused-packages -Wname-shadowing
+    -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
 
 library
   import:          language, opts-lib
@@ -51,12 +49,22 @@ library
     KelCircle.Processing
     KelCircle.Proposals
     KelCircle.Sequence
+    KelCircle.Server
+    KelCircle.Server.JSON
     KelCircle.State
+    KelCircle.Store
     KelCircle.Types
     KelCircle.Validate
+
   build-depends:
-    , base  >=4.18 && <5
-    , text  >=2.0  && <3
+    , aeson          >=2.1  && <3
+    , base           >=4.18 && <5
+    , bytestring     >=0.11 && <1
+    , http-types     >=0.12 && <1
+    , sqlite-simple  >=0.4  && <1
+    , stm            >=2.5  && <3
+    , text           >=2.0  && <3
+    , wai            >=3.2  && <4
 
 test-suite unit-tests
   import:         language, opts-test
@@ -70,11 +78,36 @@ test-suite unit-tests
     KelCircle.Test.Processing
     KelCircle.Test.Proposals
     KelCircle.Test.Sequence
+
   build-depends:
-    , base           >=4.18 && <5
+    , base              >=4.18 && <5
     , kel-circle
-    , QuickCheck     >=2.14 && <3
-    , tasty          >=1.4  && <2
-    , tasty-hunit    >=0.10 && <1
-    , tasty-quickcheck >=0.10 && <1
-    , text           >=2.0  && <3
+    , QuickCheck        >=2.14 && <3
+    , tasty             >=1.4  && <2
+    , tasty-hunit       >=0.10 && <1
+    , tasty-quickcheck  >=0.10 && <1
+    , text              >=2.0  && <3
+
+test-suite e2e-tests
+  import:         language, opts-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        E2EMain.hs
+  other-modules:
+    E2E.Spec
+    E2E.TestHelpers
+
+  build-depends:
+    , aeson        >=2.1  && <3
+    , base         >=4.18 && <5
+    , bytestring   >=0.11 && <1
+    , directory    >=1.3  && <2
+    , http-client  >=0.7  && <1
+    , http-types   >=0.12 && <1
+    , kel-circle
+    , stm          >=2.5  && <3
+    , tasty        >=1.4  && <2
+    , tasty-hunit  >=0.10 && <1
+    , temporary    >=1.3  && <2
+    , text         >=2.0  && <3
+    , warp         >=3.3  && <4

--- a/lib/KelCircle/Server.hs
+++ b/lib/KelCircle/Server.hs
@@ -1,0 +1,427 @@
+{- |
+Module      : KelCircle.Server
+Description : HTTP server for kel-circle (WAI application)
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+WAI application providing JSON endpoints for circle
+management and SSE notifications. Validates events
+through the two-level gate before appending to the
+store.
+-}
+module KelCircle.Server
+    ( ServerConfig (..)
+    , mkApp
+    ) where
+
+import Control.Concurrent.STM
+    ( TChan
+    , atomically
+    , dupTChan
+    , readTChan
+    , writeTChan
+    )
+import Data.Aeson
+    ( FromJSON
+    , ToJSON
+    , decode
+    , encode
+    , object
+    , (.=)
+    )
+import Data.ByteString (ByteString)
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Data.Text.Encoding qualified as TE
+import Data.Text.Read qualified as TR
+import KelCircle.Events
+    ( BaseDecision
+    , CircleEvent (..)
+    )
+import KelCircle.Processing (FullState (..))
+import KelCircle.Server.JSON
+    ( AppendResult (..)
+    , ServerError (..)
+    , Submission (..)
+    )
+import KelCircle.State
+    ( AuthMode (..)
+    , Circle (..)
+    , CircleState (..)
+    , authMode
+    )
+import KelCircle.Store
+    ( CircleStore (..)
+    , StoredEvent (..)
+    , appendCircleEvent
+    , readEventsFrom
+    , readFullState
+    )
+import KelCircle.Types (MemberId (..))
+import KelCircle.Validate
+    ( ValidationError
+    , validateAppDecision
+    , validateBaseDecision
+    , validateProposal
+    , validateResolve
+    , validateResponse
+    )
+import Network.HTTP.Types
+    ( HeaderName
+    , Status
+    , hContentType
+    , status200
+    , status400
+    , status401
+    , status404
+    , status422
+    )
+import Network.Wai
+    ( Application
+    , Request
+    , Response
+    , pathInfo
+    , queryString
+    , requestMethod
+    , responseLBS
+    , responseStream
+    , strictRequestBody
+    )
+
+{- | Server configuration, parameterized by application
+types.
+-}
+data ServerConfig g d p r = ServerConfig
+    { scStore :: CircleStore g p r
+    -- ^ Persistent store
+    , scAppFold :: g -> d -> g
+    -- ^ Application fold function
+    , scBaseAppGate :: g -> BaseDecision -> Bool
+    -- ^ App-level gate for base decisions
+    , scAppGate :: g -> d -> Bool
+    -- ^ App-level gate for app decisions
+    , scProposalGate :: g -> p -> Bool
+    -- ^ App-level gate for proposals
+    , scPassphrase :: Text
+    -- ^ Bootstrap passphrase
+    , scBroadcast :: TChan Int
+    -- ^ SSE broadcast channel
+    }
+
+{- | Build a WAI 'Application' from a 'ServerConfig'.
+Routes: GET /info, GET /condition, GET /events?after=N,
+POST /events, GET /stream.
+-}
+mkApp
+    :: ( FromJSON d
+       , FromJSON p
+       , FromJSON r
+       , ToJSON d
+       , ToJSON p
+       , ToJSON r
+       )
+    => ServerConfig g d p r
+    -> Application
+mkApp cfg req respond =
+    case (requestMethod req, pathInfo req) of
+        ("GET", ["info"]) ->
+            handleInfo cfg respond
+        ("GET", ["condition"]) ->
+            handleCondition cfg respond
+        ("GET", ["events"]) ->
+            handleGetEvent cfg req respond
+        ("POST", ["events"]) ->
+            handlePostEvent cfg req respond
+        ("GET", ["stream"]) ->
+            handleStream cfg respond
+        _ ->
+            respond $
+                jsonResponse status404 $
+                    BadRequest "not found"
+
+-- --------------------------------------------------------
+-- GET /info
+-- --------------------------------------------------------
+
+handleInfo
+    :: ServerConfig g d p r
+    -> (Response -> IO a)
+    -> IO a
+handleInfo cfg respond = do
+    fs <- readFullState (scStore cfg)
+    let cs = circleState (fsCircle fs)
+        mode = authMode cs
+        sid = sequencerId (fsCircle fs)
+    respond $
+        responseLBS
+            status200
+            jsonHeaders
+            ( encode $
+                object
+                    [ "authMode" .= mode
+                    , "sequencerId" .= sid
+                    , "memberCount"
+                        .= length (members cs)
+                    , "nextSeq" .= fsNextSeq fs
+                    ]
+            )
+
+-- --------------------------------------------------------
+-- GET /condition
+-- --------------------------------------------------------
+
+handleCondition
+    :: (ToJSON p, ToJSON r)
+    => ServerConfig g d p r
+    -> (Response -> IO a)
+    -> IO a
+handleCondition cfg respond = do
+    fs <- readFullState (scStore cfg)
+    let cs = circleState (fsCircle fs)
+        mode = authMode cs
+    respond $
+        responseLBS
+            status200
+            jsonHeaders
+            ( encode $
+                object
+                    [ "authMode" .= mode
+                    , "members" .= members cs
+                    , "sequencerId"
+                        .= sequencerId (fsCircle fs)
+                    , "proposals" .= fsProposals fs
+                    , "nextSeq" .= fsNextSeq fs
+                    ]
+            )
+
+-- --------------------------------------------------------
+-- GET /events?after=N
+-- --------------------------------------------------------
+
+handleGetEvent
+    :: ServerConfig g d p r
+    -> Request
+    -> (Response -> IO a)
+    -> IO a
+handleGetEvent cfg req respond =
+    case parseAfter req of
+        Nothing ->
+            respond $
+                jsonResponse status400 $
+                    BadRequest
+                        "missing or invalid ?after=N"
+        Just after -> do
+            events <-
+                readEventsFrom
+                    (scStore cfg)
+                    (after + 1)
+            case events of
+                [] ->
+                    respond $
+                        jsonResponse status404 $
+                            BadRequest
+                                "no event at position"
+                (se : _) ->
+                    respond $
+                        responseLBS
+                            status200
+                            jsonHeaders
+                            ( encode $
+                                object
+                                    [ "signer"
+                                        .= seSigner se
+                                    , "event"
+                                        .= TE.decodeUtf8
+                                            ( LBS.toStrict $
+                                                seEventJson se
+                                            )
+                                    , "signature"
+                                        .= seSignature
+                                            se
+                                    ]
+                            )
+
+-- --------------------------------------------------------
+-- POST /events
+-- --------------------------------------------------------
+
+handlePostEvent
+    :: ( FromJSON d
+       , FromJSON p
+       , FromJSON r
+       , ToJSON d
+       , ToJSON p
+       , ToJSON r
+       )
+    => ServerConfig g d p r
+    -> Request
+    -> (Response -> IO a)
+    -> IO a
+handlePostEvent cfg req respond = do
+    body <- strictRequestBody req
+    case decode body of
+        Nothing ->
+            respond $
+                jsonResponse status400 $
+                    BadRequest "invalid JSON"
+        Just sub -> do
+            fs <- readFullState (scStore cfg)
+            let cs = circleState (fsCircle fs)
+                mode = authMode cs
+            case mode of
+                Bootstrap ->
+                    handleBootstrapPost
+                        cfg
+                        sub
+                        fs
+                        respond
+                Normal ->
+                    doAppend cfg sub fs respond
+
+handleBootstrapPost
+    :: (ToJSON d, ToJSON p, ToJSON r)
+    => ServerConfig g d p r
+    -> Submission d p r
+    -> FullState g p r
+    -> (Response -> IO a)
+    -> IO a
+handleBootstrapPost cfg sub fs respond =
+    case subPassphrase sub of
+        Nothing ->
+            respond $
+                jsonResponse
+                    status401
+                    PassphraseRequired
+        Just pass
+            | pass /= scPassphrase cfg ->
+                respond $
+                    jsonResponse
+                        status401
+                        WrongPassphrase
+            | otherwise ->
+                doAppend cfg sub fs respond
+
+doAppend
+    :: (ToJSON d, ToJSON p, ToJSON r)
+    => ServerConfig g d p r
+    -> Submission d p r
+    -> FullState g p r
+    -> (Response -> IO a)
+    -> IO a
+doAppend cfg sub fs respond = do
+    let signer = MemberId (subSigner sub)
+        evt = subEvent sub
+    case validateCircleEvent cfg fs signer evt of
+        Left ve ->
+            respond $
+                jsonResponse status422 $
+                    ValidationErr ve
+        Right () -> do
+            sn <-
+                appendCircleEvent
+                    (scStore cfg)
+                    (scAppFold cfg)
+                    (subSigner sub)
+                    (subSignature sub)
+                    evt
+            atomically $
+                writeTChan (scBroadcast cfg) sn
+            respond $
+                responseLBS
+                    status200
+                    jsonHeaders
+                    (encode $ AppendResult sn)
+
+{- | Validate a circle event through the appropriate
+gate.
+-}
+validateCircleEvent
+    :: ServerConfig g d p r
+    -> FullState g p r
+    -> MemberId
+    -> CircleEvent d p r
+    -> Either ValidationError ()
+validateCircleEvent cfg fs signer = \case
+    CEBaseDecision bd ->
+        validateBaseDecision
+            fs
+            signer
+            bd
+            (scBaseAppGate cfg)
+    CEAppDecision d ->
+        validateAppDecision
+            fs
+            signer
+            d
+            (scAppGate cfg)
+    CEProposal content _deadline ->
+        validateProposal
+            fs
+            signer
+            content
+            (scProposalGate cfg)
+    CEResponse _content pid ->
+        validateResponse fs signer pid
+    CEResolveProposal _pid _res ->
+        validateResolve fs signer
+
+-- --------------------------------------------------------
+-- GET /stream (SSE)
+-- --------------------------------------------------------
+
+handleStream
+    :: ServerConfig g d p r
+    -> (Response -> IO a)
+    -> IO a
+handleStream cfg respond =
+    respond $
+        responseStream status200 sseHeaders $
+            \write flush -> do
+                ch <-
+                    atomically $
+                        dupTChan (scBroadcast cfg)
+                let loop = do
+                        sn <-
+                            atomically $ readTChan ch
+                        write $
+                            Builder.byteString
+                                "event: new\ndata: \
+                                \{\"sn\":"
+                                <> Builder.intDec sn
+                                <> Builder.byteString
+                                    "}\n\n"
+                        flush
+                        loop
+                loop
+
+-- --------------------------------------------------------
+-- Helpers
+-- --------------------------------------------------------
+
+-- | Parse the ?after=N query parameter.
+parseAfter :: Request -> Maybe Int
+parseAfter req =
+    case lookup "after" (queryString req) of
+        Just (Just bs) ->
+            case TR.signed
+                TR.decimal
+                (TE.decodeUtf8 bs) of
+                Right (n, _) -> Just n
+                Left _ -> Nothing
+        _ -> Nothing
+
+jsonHeaders :: [(HeaderName, ByteString)]
+jsonHeaders =
+    [(hContentType, "application/json")]
+
+sseHeaders :: [(HeaderName, ByteString)]
+sseHeaders =
+    [ (hContentType, "text/event-stream")
+    , ("Cache-Control", "no-cache")
+    ]
+
+jsonResponse
+    :: (ToJSON e) => Status -> e -> Response
+jsonResponse status body =
+    responseLBS status jsonHeaders (encode body)

--- a/lib/KelCircle/Server/JSON.hs
+++ b/lib/KelCircle/Server/JSON.hs
@@ -1,0 +1,388 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- |
+Module      : KelCircle.Server.JSON
+Description : Aeson instances for kel-circle types and HTTP types
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Orphan 'ToJSON' and 'FromJSON' instances for all event
+and state types. Kept separate to avoid an @aeson@
+dependency in the core modules. Also defines HTTP-specific
+types: 'Submission', 'AppendResult', 'ServerError'.
+-}
+module KelCircle.Server.JSON
+    ( Submission (..)
+    , AppendResult (..)
+    , ServerError (..)
+    ) where
+
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    , Value (..)
+    , object
+    , withObject
+    , withText
+    , (.:)
+    , (.:?)
+    , (.=)
+    )
+import Data.Text (Text)
+import KelCircle.Events
+    ( BaseDecision (..)
+    , CircleEvent (..)
+    , Resolution (..)
+    )
+import KelCircle.Proposals
+    ( ProposalStatus (..)
+    , TrackedProposal (..)
+    )
+import KelCircle.State (AuthMode (..))
+import KelCircle.Types
+    ( Member (..)
+    , MemberId (..)
+    , Role (..)
+    )
+import KelCircle.Validate (ValidationError (..))
+
+-- --------------------------------------------------------
+-- HTTP-specific types
+-- --------------------------------------------------------
+
+-- | A submission from a client to append an event.
+data Submission d p r = Submission
+    { subPassphrase :: Maybe Text
+    -- ^ Required in bootstrap mode
+    , subSigner :: Text
+    -- ^ CESR-encoded public key
+    , subSignature :: Text
+    -- ^ CESR-encoded Ed25519 signature
+    , subEvent :: CircleEvent d p r
+    -- ^ The event to append
+    }
+    deriving stock (Show, Eq)
+
+-- | Successful append result.
+newtype AppendResult = AppendResult
+    { sequenceNumber :: Int
+    }
+    deriving stock (Show, Eq)
+
+-- | Server-level errors.
+data ServerError
+    = ValidationErr ValidationError
+    | PassphraseRequired
+    | WrongPassphrase
+    | SignatureError Text
+    | BadRequest Text
+    deriving stock (Show, Eq)
+
+-- --------------------------------------------------------
+-- Role
+-- --------------------------------------------------------
+
+instance ToJSON Role where
+    toJSON Admin = String "admin"
+    toJSON Member = String "member"
+
+instance FromJSON Role where
+    parseJSON = withText "Role" $ \case
+        "admin" -> pure Admin
+        "member" -> pure Member
+        t -> fail $ "unknown Role: " <> show t
+
+-- --------------------------------------------------------
+-- MemberId
+-- --------------------------------------------------------
+
+instance ToJSON MemberId where
+    toJSON (MemberId t) = toJSON t
+
+instance FromJSON MemberId where
+    parseJSON v = MemberId <$> parseJSON v
+
+-- --------------------------------------------------------
+-- Member
+-- --------------------------------------------------------
+
+instance ToJSON Member where
+    toJSON m =
+        object
+            [ "memberId" .= memberId m
+            , "role" .= memberRole m
+            ]
+
+instance FromJSON Member where
+    parseJSON = withObject "Member" $ \o ->
+        MemberRecord
+            <$> o .: "memberId"
+            <*> o .: "role"
+
+-- --------------------------------------------------------
+-- ProposalStatus
+-- --------------------------------------------------------
+
+instance ToJSON ProposalStatus where
+    toJSON Open = String "open"
+    toJSON (Resolved r) =
+        object
+            [ "tag" .= ("resolved" :: Text)
+            , "resolution" .= r
+            ]
+
+-- --------------------------------------------------------
+-- TrackedProposal
+-- --------------------------------------------------------
+
+instance
+    (ToJSON p, ToJSON r)
+    => ToJSON (TrackedProposal p r)
+    where
+    toJSON tp =
+        object
+            [ "proposalId" .= tpProposalId tp
+            , "content" .= tpContent tp
+            , "proposer" .= tpProposer tp
+            , "deadline" .= tpDeadline tp
+            , "responses" .= tpResponses tp
+            , "respondents" .= tpRespondents tp
+            , "status" .= tpStatus tp
+            ]
+
+-- --------------------------------------------------------
+-- BaseDecision
+-- --------------------------------------------------------
+
+instance ToJSON BaseDecision where
+    toJSON (IntroduceMember mid role) =
+        object
+            [ "tag" .= ("introduceMember" :: Text)
+            , "memberId" .= mid
+            , "role" .= role
+            ]
+    toJSON (RemoveMember mid) =
+        object
+            [ "tag" .= ("removeMember" :: Text)
+            , "memberId" .= mid
+            ]
+    toJSON (ChangeRole mid role) =
+        object
+            [ "tag" .= ("changeRole" :: Text)
+            , "memberId" .= mid
+            , "role" .= role
+            ]
+    toJSON (RotateSequencer mid) =
+        object
+            [ "tag" .= ("rotateSequencer" :: Text)
+            , "memberId" .= mid
+            ]
+
+instance FromJSON BaseDecision where
+    parseJSON = withObject "BaseDecision" $ \o -> do
+        (tag :: Text) <- o .: "tag"
+        case tag of
+            "introduceMember" ->
+                IntroduceMember <$> o .: "memberId" <*> o .: "role"
+            "removeMember" ->
+                RemoveMember <$> o .: "memberId"
+            "changeRole" ->
+                ChangeRole <$> o .: "memberId" <*> o .: "role"
+            "rotateSequencer" ->
+                RotateSequencer <$> o .: "memberId"
+            _ -> fail $ "unknown BaseDecision tag: " <> show tag
+
+-- --------------------------------------------------------
+-- Resolution
+-- --------------------------------------------------------
+
+instance ToJSON Resolution where
+    toJSON ThresholdReached = String "thresholdReached"
+    toJSON ProposerPositive = String "proposerPositive"
+    toJSON ProposerNegative = String "proposerNegative"
+    toJSON Timeout = String "timeout"
+
+instance FromJSON Resolution where
+    parseJSON = withText "Resolution" $ \case
+        "thresholdReached" -> pure ThresholdReached
+        "proposerPositive" -> pure ProposerPositive
+        "proposerNegative" -> pure ProposerNegative
+        "timeout" -> pure Timeout
+        t -> fail $ "unknown Resolution: " <> show t
+
+-- --------------------------------------------------------
+-- CircleEvent d p r
+-- --------------------------------------------------------
+
+instance
+    (ToJSON d, ToJSON p, ToJSON r)
+    => ToJSON (CircleEvent d p r)
+    where
+    toJSON (CEBaseDecision bd) =
+        object
+            [ "tag" .= ("baseDecision" :: Text)
+            , "decision" .= bd
+            ]
+    toJSON (CEAppDecision d) =
+        object
+            [ "tag" .= ("appDecision" :: Text)
+            , "decision" .= d
+            ]
+    toJSON (CEProposal p deadline) =
+        object
+            [ "tag" .= ("proposal" :: Text)
+            , "content" .= p
+            , "deadline" .= deadline
+            ]
+    toJSON (CEResponse r pid) =
+        object
+            [ "tag" .= ("response" :: Text)
+            , "content" .= r
+            , "proposalId" .= pid
+            ]
+    toJSON (CEResolveProposal pid res) =
+        object
+            [ "tag" .= ("resolveProposal" :: Text)
+            , "proposalId" .= pid
+            , "resolution" .= res
+            ]
+
+instance
+    (FromJSON d, FromJSON p, FromJSON r)
+    => FromJSON (CircleEvent d p r)
+    where
+    parseJSON = withObject "CircleEvent" $ \o -> do
+        (tag :: Text) <- o .: "tag"
+        case tag of
+            "baseDecision" ->
+                CEBaseDecision <$> o .: "decision"
+            "appDecision" ->
+                CEAppDecision <$> o .: "decision"
+            "proposal" ->
+                CEProposal <$> o .: "content" <*> o .: "deadline"
+            "response" ->
+                CEResponse <$> o .: "content" <*> o .: "proposalId"
+            "resolveProposal" ->
+                CEResolveProposal
+                    <$> o .: "proposalId"
+                    <*> o .: "resolution"
+            _ -> fail $ "unknown CircleEvent tag: " <> show tag
+
+-- --------------------------------------------------------
+-- AuthMode
+-- --------------------------------------------------------
+
+instance ToJSON AuthMode where
+    toJSON Bootstrap = String "bootstrap"
+    toJSON Normal = String "normal"
+
+instance FromJSON AuthMode where
+    parseJSON = withText "AuthMode" $ \case
+        "bootstrap" -> pure Bootstrap
+        "normal" -> pure Normal
+        t -> fail $ "unknown AuthMode: " <> show t
+
+-- --------------------------------------------------------
+-- ValidationError
+-- --------------------------------------------------------
+
+instance ToJSON ValidationError where
+    toJSON (BaseGateRejected bd) =
+        object
+            [ "error"
+                .= ("baseGateRejected" :: Text)
+            , "decision" .= bd
+            ]
+    toJSON AppGateRejected =
+        object
+            [ "error"
+                .= ("appGateRejected" :: Text)
+            ]
+    toJSON ProposalGateRejected =
+        object
+            [ "error"
+                .= ( "proposalGateRejected"
+                        :: Text
+                   )
+            ]
+    toJSON (ResponseGateRejected pid) =
+        object
+            [ "error"
+                .= ( "responseGateRejected"
+                        :: Text
+                   )
+            , "proposalId" .= pid
+            ]
+    toJSON (NotSequencer mid) =
+        object
+            [ "error"
+                .= ("notSequencer" :: Text)
+            , "memberId" .= mid
+            ]
+
+-- --------------------------------------------------------
+-- Submission
+-- --------------------------------------------------------
+
+instance
+    (ToJSON d, ToJSON p, ToJSON r)
+    => ToJSON (Submission d p r)
+    where
+    toJSON s =
+        object
+            [ "passphrase" .= subPassphrase s
+            , "signer" .= subSigner s
+            , "signature" .= subSignature s
+            , "event" .= subEvent s
+            ]
+
+instance
+    (FromJSON d, FromJSON p, FromJSON r)
+    => FromJSON (Submission d p r)
+    where
+    parseJSON = withObject "Submission" $ \o ->
+        Submission
+            <$> o .:? "passphrase"
+            <*> o .: "signer"
+            <*> o .: "signature"
+            <*> o .: "event"
+
+-- --------------------------------------------------------
+-- AppendResult
+-- --------------------------------------------------------
+
+instance ToJSON AppendResult where
+    toJSON r =
+        object
+            ["sequenceNumber" .= sequenceNumber r]
+
+instance FromJSON AppendResult where
+    parseJSON = withObject "AppendResult" $ \o ->
+        AppendResult <$> o .: "sequenceNumber"
+
+-- --------------------------------------------------------
+-- ServerError
+-- --------------------------------------------------------
+
+instance ToJSON ServerError where
+    toJSON (ValidationErr ve) =
+        object
+            [ "error" .= ("validationError" :: Text)
+            , "detail" .= ve
+            ]
+    toJSON PassphraseRequired =
+        object
+            ["error" .= ("passphraseRequired" :: Text)]
+    toJSON WrongPassphrase =
+        object
+            ["error" .= ("wrongPassphrase" :: Text)]
+    toJSON (SignatureError msg) =
+        object
+            [ "error" .= ("signatureError" :: Text)
+            , "message" .= msg
+            ]
+    toJSON (BadRequest msg) =
+        object
+            [ "error" .= ("badRequest" :: Text)
+            , "message" .= msg
+            ]

--- a/lib/KelCircle/Store.hs
+++ b/lib/KelCircle/Store.hs
@@ -1,0 +1,248 @@
+{- |
+Module      : KelCircle.Store
+Description : SQLite-backed global sequence store
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Persistent append-only store for the global sequence,
+backed by SQLite. Each event is stored as JSON along
+with the signer key and Ed25519 signature. The server
+maintains a hot @FullState@ in a @TVar@ for O(1) reads.
+-}
+module KelCircle.Store
+    ( -- * Store handle
+      CircleStore (..)
+
+      -- * Lifecycle
+    , openStore
+    , closeStore
+
+      -- * Operations
+    , appendCircleEvent
+    , readFullState
+    , readEventsFrom
+    , storeLength
+
+      -- * Stored event
+    , StoredEvent (..)
+    ) where
+
+import Control.Concurrent.STM
+    ( TVar
+    , atomically
+    , newTVarIO
+    , readTVar
+    , readTVarIO
+    , writeTVar
+    )
+import Data.Aeson (FromJSON, ToJSON, decode, encode)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Database.SQLite.Simple
+    ( Connection
+    , Only (..)
+    , close
+    , execute
+    , execute_
+    , open
+    , query
+    , query_
+    )
+import KelCircle.Events (CircleEvent (..))
+import KelCircle.Processing
+    ( FullState (..)
+    , applyAppDecision
+    , applyBase
+    , applyProposal
+    , applyResolve
+    , applyResponse
+    , initFullState
+    )
+import KelCircle.Server.JSON ()
+import KelCircle.Types (MemberId (..))
+
+{- | A stored event as returned by 'readEventsFrom'.
+Contains the signer key, event JSON, and signature.
+-}
+data StoredEvent = StoredEvent
+    { seSigner :: Text
+    -- ^ Signer public key
+    , seEventJson :: LBS.ByteString
+    -- ^ JSON-encoded CircleEvent
+    , seSignature :: Text
+    -- ^ Ed25519 signature (hex or CESR)
+    }
+    deriving stock (Show, Eq)
+
+-- | A handle to a SQLite-backed circle store.
+data CircleStore g p r = CircleStore
+    { csConn :: Connection
+    -- ^ SQLite connection
+    , csState :: TVar (FullState g p r)
+    -- ^ Hot state updated incrementally
+    , csLength :: TVar Int
+    -- ^ Number of events in the store
+    }
+
+{- | Open or create a circle store at the given path.
+Creates the events table on first open and replays
+existing events to rebuild the in-memory state.
+-}
+openStore
+    :: ( FromJSON d
+       , FromJSON p
+       , FromJSON r
+       )
+    => MemberId
+    -- ^ Sequencer member id
+    -> g
+    -- ^ Initial application state
+    -> (g -> d -> g)
+    -- ^ Application fold function
+    -> FilePath
+    -> IO (CircleStore g p r)
+openStore sid initApp appFold path = do
+    conn <- open path
+    execute_
+        conn
+        "CREATE TABLE IF NOT EXISTS events \
+        \( id INTEGER PRIMARY KEY AUTOINCREMENT \
+        \, signer TEXT NOT NULL \
+        \, event_json TEXT NOT NULL \
+        \, signature TEXT NOT NULL \
+        \)"
+    -- Replay events to rebuild state
+    rows <-
+        query_
+            conn
+            "SELECT signer, event_json FROM events \
+            \ORDER BY id"
+            :: IO [(Text, LBS.ByteString)]
+    let initialState = initFullState sid initApp
+        finalState =
+            foldl
+                (replayRow appFold)
+                initialState
+                rows
+    stVar <- newTVarIO finalState
+    [Only n] <-
+        query_
+            conn
+            "SELECT COUNT(*) FROM events"
+    lVar <- newTVarIO (n :: Int)
+    pure
+        CircleStore
+            { csConn = conn
+            , csState = stVar
+            , csLength = lVar
+            }
+
+-- | Close the store.
+closeStore :: CircleStore g p r -> IO ()
+closeStore = close . csConn
+
+{- | Append a verified event. Persists to SQLite and
+updates the in-memory state. The caller is responsible
+for validation before calling this.
+-}
+appendCircleEvent
+    :: (ToJSON d, ToJSON p, ToJSON r)
+    => CircleStore g p r
+    -> (g -> d -> g)
+    -- ^ Application fold function
+    -> Text
+    -- ^ Signer key
+    -> Text
+    -- ^ Signature
+    -> CircleEvent d p r
+    -- ^ The event to store
+    -> IO Int
+appendCircleEvent store appFold signer sig evt = do
+    let eventJson = encode evt
+    execute
+        (csConn store)
+        "INSERT INTO events \
+        \(signer, event_json, signature) \
+        \VALUES (?, ?, ?)"
+        (signer, eventJson, sig)
+    atomically $ do
+        st <- readTVar (csState store)
+        writeTVar (csState store) $
+            applyEvent appFold st (MemberId signer) evt
+        n <- readTVar (csLength store)
+        let n' = n + 1
+        writeTVar (csLength store) n'
+        pure n'
+
+-- | Read current full state (from TVar, O(1)).
+readFullState :: CircleStore g p r -> IO (FullState g p r)
+readFullState = readTVarIO . csState
+
+{- | Read events from index @n@ onward (1-based,
+matching SQLite rowid).
+-}
+readEventsFrom
+    :: CircleStore g p r
+    -> Int
+    -> IO [StoredEvent]
+readEventsFrom store n = do
+    rows <-
+        query
+            (csConn store)
+            "SELECT signer, event_json, signature \
+            \FROM events WHERE id >= ? ORDER BY id"
+            (Only n)
+            :: IO [(Text, LBS.ByteString, Text)]
+    pure $ map toStoredEvent rows
+  where
+    toStoredEvent (s, ej, sig) =
+        StoredEvent
+            { seSigner = s
+            , seEventJson = ej
+            , seSignature = sig
+            }
+
+-- | Number of events in the store.
+storeLength :: CircleStore g p r -> IO Int
+storeLength = readTVarIO . csLength
+
+-- --------------------------------------------------------
+-- Internal helpers
+-- --------------------------------------------------------
+
+-- | Apply a circle event to the full state.
+applyEvent
+    :: (g -> d -> g)
+    -> FullState g p r
+    -> MemberId
+    -> CircleEvent d p r
+    -> FullState g p r
+applyEvent appFold st signer = \case
+    CEBaseDecision bd -> applyBase st bd
+    CEAppDecision d ->
+        applyAppDecision st d appFold
+    CEProposal content deadline ->
+        applyProposal st content signer deadline
+    CEResponse content pid ->
+        applyResponse st content signer pid
+    CEResolveProposal pid res ->
+        applyResolve st pid res
+
+{- | Replay a single row from the database into the
+full state.
+-}
+replayRow
+    :: (FromJSON d, FromJSON p, FromJSON r)
+    => (g -> d -> g)
+    -> FullState g p r
+    -> (Text, LBS.ByteString)
+    -> FullState g p r
+replayRow appFold st (signer, eventJson) =
+    case decode eventJson of
+        Just evt ->
+            applyEvent
+                appFold
+                st
+                (MemberId signer)
+                evt
+        Nothing -> st

--- a/test/E2E/Spec.hs
+++ b/test/E2E/Spec.hs
@@ -1,0 +1,405 @@
+{- |
+Module      : E2E.Spec
+Description : End-to-end scenarios through the HTTP API
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Multi-step workflows exercising the full circle
+lifecycle via HTTP calls: bootstrap, member management,
+proposals, responses, and resolution.
+-}
+module E2E.Spec (tests) where
+
+import Data.Aeson (encode)
+import E2E.TestHelpers
+import KelCircle.Events (Resolution (..))
+import KelCircle.Server.JSON (Submission (..))
+import KelCircle.Types (Role (..))
+import Network.HTTP.Client qualified as HC
+import Network.HTTP.Types
+    ( status200
+    , status401
+    , status422
+    )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+
+-- | All E2E test scenarios.
+tests :: TestTree
+tests =
+    testGroup
+        "E2E scenarios"
+        [ bootstrapTests
+        , memberTests
+        , roleTests
+        , proposalTests
+        , authTests
+        , rebootstrapTests
+        , eventReplayTests
+        ]
+
+-- --------------------------------------------------------
+-- Bootstrap
+-- --------------------------------------------------------
+
+bootstrapTests :: TestTree
+bootstrapTests =
+    testGroup
+        "Bootstrap"
+        [ testCase
+            "bootstrap first admin"
+            testBootstrapFirstAdmin
+        , testCase
+            "bootstrap rejects missing passphrase"
+            testBootstrapMissingPass
+        , testCase
+            "bootstrap rejects wrong passphrase"
+            testBootstrapWrongPass
+        ]
+
+testBootstrapFirstAdmin :: IO ()
+testBootstrapFirstAdmin = withTestEnv $ \te -> do
+    -- Initially in bootstrap mode
+    info0 <- getInfo te
+    irAuthMode info0 @?= "bootstrap"
+    irMemberCount info0 @?= 1 -- server-sequencer
+    admin1 <- newTestId
+    sn <- postEvent te (bootstrapAdmin admin1)
+    -- First appended event = sequence 1
+    sn @?= 1
+
+    info1 <- getInfo te
+    irAuthMode info1 @?= "normal"
+    irMemberCount info1 @?= 2 -- sequencer + admin
+
+testBootstrapMissingPass :: IO ()
+testBootstrapMissingPass = withTestEnv $ \te -> do
+    admin1 <- newTestId
+    let sub = signSubmission (bootstrapAdmin admin1)
+        sub' = sub{subPassphrase = Nothing}
+    resp <- httpPost te "/events" (encode sub')
+    HC.responseStatus resp @?= status401
+
+testBootstrapWrongPass :: IO ()
+testBootstrapWrongPass = withTestEnv $ \te -> do
+    admin1 <- newTestId
+    let sub = signSubmission (bootstrapAdmin admin1)
+        sub' =
+            sub{subPassphrase = Just "wrong"}
+    resp <- httpPost te "/events" (encode sub')
+    HC.responseStatus resp @?= status401
+
+-- --------------------------------------------------------
+-- Member management
+-- --------------------------------------------------------
+
+memberTests :: TestTree
+memberTests =
+    testGroup
+        "Member management"
+        [ testCase
+            "admin introduces member"
+            testIntroduceMember
+        , testCase
+            "admin removes member"
+            testRemoveMember
+        , testCase
+            "non-admin cannot introduce"
+            testNonAdminCannotIntroduce
+        , testCase
+            "non-member cannot introduce"
+            testNonMemberCannotIntroduce
+        , testCase
+            "duplicate member rejected"
+            testDuplicateMember
+        ]
+
+testIntroduceMember :: IO ()
+testIntroduceMember = withTestEnv $ \te -> do
+    admin1 <- newTestId
+    user1 <- newTestId
+
+    _ <- postEvent te (bootstrapAdmin admin1)
+    _ <- postEvent te (introduceMember admin1 user1)
+
+    cond <- getCondition te
+    length (crMembers cond) @?= 3
+
+testRemoveMember :: IO ()
+testRemoveMember = withTestEnv $ \te -> do
+    admin1 <- newTestId
+    user1 <- newTestId
+
+    _ <- postEvent te (bootstrapAdmin admin1)
+    _ <- postEvent te (introduceMember admin1 user1)
+
+    cond0 <- getCondition te
+    length (crMembers cond0) @?= 3
+
+    _ <- postEvent te (removeMember admin1 user1)
+
+    cond1 <- getCondition te
+    length (crMembers cond1) @?= 2
+
+testNonAdminCannotIntroduce :: IO ()
+testNonAdminCannotIntroduce =
+    withTestEnv $ \te -> do
+        admin1 <- newTestId
+        user1 <- newTestId
+        user2 <- newTestId
+
+        _ <- postEvent te (bootstrapAdmin admin1)
+        _ <-
+            postEvent
+                te
+                (introduceMember admin1 user1)
+
+        resp <-
+            postEventRaw
+                te
+                (introduceMember user1 user2)
+        HC.responseStatus resp @?= status422
+
+testNonMemberCannotIntroduce :: IO ()
+testNonMemberCannotIntroduce =
+    withTestEnv $ \te -> do
+        admin1 <- newTestId
+        nobody <- newTestId
+        user1 <- newTestId
+
+        _ <- postEvent te (bootstrapAdmin admin1)
+
+        resp <-
+            postEventRaw
+                te
+                (introduceMember nobody user1)
+        HC.responseStatus resp @?= status422
+
+testDuplicateMember :: IO ()
+testDuplicateMember = withTestEnv $ \te -> do
+    admin1 <- newTestId
+
+    _ <- postEvent te (bootstrapAdmin admin1)
+
+    -- Try to introduce admin1 again
+    resp <-
+        postEventRaw
+            te
+            (introduceAdmin admin1 admin1)
+    -- Should be rejected by the base gate
+    HC.responseStatus resp @?= status422
+
+-- --------------------------------------------------------
+-- Role changes
+-- --------------------------------------------------------
+
+roleTests :: TestTree
+roleTests =
+    testGroup
+        "Role changes"
+        [ testCase
+            "role change requires proposal (rejected as straight decision)"
+            testRoleChangeRequiresProposal
+        , testCase
+            "admin introduction requires proposal in normal mode"
+            testAdminIntroRequiresProposal
+        ]
+
+testRoleChangeRequiresProposal :: IO ()
+testRoleChangeRequiresProposal =
+    withTestEnv $ \te -> do
+        admin1 <- newTestId
+        user1 <- newTestId
+
+        _ <- postEvent te (bootstrapAdmin admin1)
+        _ <-
+            postEvent
+                te
+                (introduceMember admin1 user1)
+
+        -- ChangeRole requires majority,
+        -- rejected as straight decision
+        resp <-
+            postEventRaw
+                te
+                (changeRole admin1 user1 Admin)
+        HC.responseStatus resp @?= status422
+
+testAdminIntroRequiresProposal :: IO ()
+testAdminIntroRequiresProposal =
+    withTestEnv $ \te -> do
+        admin1 <- newTestId
+        admin2 <- newTestId
+
+        _ <- postEvent te (bootstrapAdmin admin1)
+
+        -- IntroduceMember _ Admin requires majority
+        -- in normal mode
+        resp <-
+            postEventRaw
+                te
+                (introduceAdmin admin1 admin2)
+        HC.responseStatus resp @?= status422
+
+-- --------------------------------------------------------
+-- Proposals
+-- --------------------------------------------------------
+
+proposalTests :: TestTree
+proposalTests =
+    testGroup
+        "Proposals"
+        [ testCase
+            "open proposal and respond"
+            testProposalAndResponse
+        , testCase
+            "resolve proposal"
+            testResolveProposal
+        ]
+
+testProposalAndResponse :: IO ()
+testProposalAndResponse = withTestEnv $ \te -> do
+    admin1 <- newTestId
+    user1 <- newTestId
+
+    _ <- postEvent te (bootstrapAdmin admin1)
+    _ <- postEvent te (introduceMember admin1 user1)
+
+    -- Admin opens a proposal (deadline = 9999)
+    proposalSn <-
+        postEvent te (submitProposal admin1 9999)
+    -- proposal id = sequence number when opened
+    let pid = proposalSn
+
+    -- User responds
+    _ <-
+        postEvent
+            te
+            (respondToProposal user1 pid)
+
+    cond <- getCondition te
+    length (crProposals cond) @?= 1
+
+testResolveProposal :: IO ()
+testResolveProposal = withTestEnv $ \te -> do
+    -- The sequencer can resolve proposals
+    let seqId =
+            TestId{tidKey = "server-sequencer"}
+    admin1 <- newTestId
+
+    _ <- postEvent te (bootstrapAdmin admin1)
+
+    proposalSn <-
+        postEvent te (submitProposal admin1 9999)
+    let pid = proposalSn
+
+    _ <-
+        postEvent
+            te
+            ( resolveProposal
+                seqId
+                pid
+                ProposerPositive
+            )
+
+    cond <- getCondition te
+    -- Proposal still in list (resolved)
+    length (crProposals cond) @?= 1
+
+-- --------------------------------------------------------
+-- Auth edge cases
+-- --------------------------------------------------------
+
+authTests :: TestTree
+authTests =
+    testGroup
+        "Authorization"
+        [ testCase
+            "after bootstrap, passphrase not needed"
+            testNormalNoPass
+        ]
+
+testNormalNoPass :: IO ()
+testNormalNoPass = withTestEnv $ \te -> do
+    admin1 <- newTestId
+    user1 <- newTestId
+
+    _ <- postEvent te (bootstrapAdmin admin1)
+
+    -- Normal mode: passphrase not needed
+    sn <-
+        postEvent
+            te
+            (introduceMember admin1 user1)
+    sn @?= 2
+
+-- --------------------------------------------------------
+-- Re-bootstrap
+-- --------------------------------------------------------
+
+rebootstrapTests :: TestTree
+rebootstrapTests =
+    testGroup
+        "Re-bootstrap"
+        [ testCase
+            "removing last admin allows re-bootstrap"
+            testRebootstrap
+        ]
+
+testRebootstrap :: IO ()
+testRebootstrap = withTestEnv $ \te -> do
+    admin1 <- newTestId
+    admin2 <- newTestId
+
+    _ <- postEvent te (bootstrapAdmin admin1)
+
+    info0 <- getInfo te
+    irAuthMode info0 @?= "normal"
+
+    -- Remove the admin
+    _ <- postEvent te (removeMember admin1 admin1)
+
+    info1 <- getInfo te
+    -- Should still be normal because
+    -- server-sequencer is a Member (from genesis)
+    -- but no Admin exists
+    irAuthMode info1 @?= "bootstrap"
+
+    -- New admin can bootstrap
+    _ <- postEvent te (bootstrapAdmin admin2)
+
+    info2 <- getInfo te
+    irAuthMode info2 @?= "normal"
+
+-- --------------------------------------------------------
+-- Event replay
+-- --------------------------------------------------------
+
+eventReplayTests :: TestTree
+eventReplayTests =
+    testGroup
+        "Event replay"
+        [ testCase
+            "GET /events replays from offset"
+            testEventReplay
+        ]
+
+testEventReplay :: IO ()
+testEventReplay = withTestEnv $ \te -> do
+    admin1 <- newTestId
+    user1 <- newTestId
+
+    _ <- postEvent te (bootstrapAdmin admin1)
+    _ <- postEvent te (introduceMember admin1 user1)
+
+    -- Read first event (after=-1 means from id=0)
+    e0 <- httpGet te "/events?after=-1"
+    HC.responseStatus e0 @?= status200
+
+    -- Read second event
+    e1 <- httpGet te "/events?after=0"
+    HC.responseStatus e1 @?= status200
+
+    -- Read third event
+    e2 <- httpGet te "/events?after=1"
+    HC.responseStatus e2 @?= status200

--- a/test/E2E/TestHelpers.hs
+++ b/test/E2E/TestHelpers.hs
@@ -1,0 +1,474 @@
+{- |
+Module      : E2E.TestHelpers
+Description : Test infrastructure for E2E scenarios
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Reusable test environment, HTTP helpers, and submission
+builders for integration tests.
+-}
+module E2E.TestHelpers
+    ( -- * Test environment
+      TestEnv (..)
+    , withTestEnv
+
+      -- * HTTP helpers
+    , httpGet
+    , httpPost
+    , postEvent
+    , postEventRaw
+    , getInfo
+    , getCondition
+    , decodeOrFail
+
+      -- * Test identities
+    , TestId (..)
+    , newTestId
+
+      -- * Submission builders
+    , TestSub (..)
+    , testPass
+    , bootstrapAdmin
+    , introduceMember
+    , introduceAdmin
+    , removeMember
+    , changeRole
+    , submitProposal
+    , respondToProposal
+    , resolveProposal
+
+      -- * Signing
+    , signSubmission
+
+      -- * Response decoders
+    , InfoResp (..)
+    , ConditionResp (..)
+    , ConditionMember (..)
+    ) where
+
+import Control.Concurrent.STM (newBroadcastTChanIO)
+import Data.Aeson
+    ( FromJSON (..)
+    , Value
+    , decode
+    , encode
+    , withObject
+    , (.:)
+    )
+import Data.ByteString.Lazy qualified as LBS
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , newIORef
+    )
+import Data.Text (Text)
+import Data.Text qualified as T
+import KelCircle.Events
+    ( BaseDecision (..)
+    , CircleEvent (..)
+    , Resolution
+    )
+import KelCircle.Server (ServerConfig (..), mkApp)
+import KelCircle.Server.JSON
+    ( AppendResult (..)
+    , Submission (..)
+    )
+import KelCircle.Store
+    ( CircleStore
+    , closeStore
+    , openStore
+    )
+import KelCircle.Types
+    ( MemberId (..)
+    , ProposalId
+    , Role (..)
+    , Timestamp
+    )
+import Network.HTTP.Client qualified as HC
+import Network.HTTP.Types (status200)
+import Network.Wai.Handler.Warp qualified as Warp
+import System.Directory (removeFile)
+import System.IO.Temp (emptySystemTempFile)
+import System.IO.Unsafe (unsafePerformIO)
+import Test.Tasty.HUnit (assertEqual)
+
+-- --------------------------------------------------------
+-- Unique key generation
+-- --------------------------------------------------------
+
+{-# NOINLINE keyCounter #-}
+keyCounter :: IORef Int
+keyCounter = unsafePerformIO (newIORef 0)
+
+-- | Generate a unique key string.
+uniqueKey :: IO Text
+uniqueKey = do
+    n <-
+        atomicModifyIORef'
+            keyCounter
+            (\i -> (i + 1, i))
+    pure $ "test-key-" <> T.pack (show n)
+
+-- --------------------------------------------------------
+-- Test identities
+-- --------------------------------------------------------
+
+-- | A test identity with a unique key.
+newtype TestId = TestId
+    { tidKey :: Text
+    -- ^ Unique public key string
+    }
+    deriving stock (Show, Eq)
+
+-- | Generate a fresh test identity.
+newTestId :: IO TestId
+newTestId = TestId <$> uniqueKey
+
+-- --------------------------------------------------------
+-- Passphrase
+-- --------------------------------------------------------
+
+-- | Passphrase used in all tests.
+testPass :: Text
+testPass = "e2e-bootstrap-pass"
+
+-- --------------------------------------------------------
+-- Test environment
+-- --------------------------------------------------------
+
+-- | Test environment with a running server.
+data TestEnv = TestEnv
+    { tePort :: Warp.Port
+    , teMgr :: HC.Manager
+    }
+
+{- | Spin up a fresh server on a random port. Uses
+the trivial application (Unit types for d, p, r).
+-}
+withTestEnv :: (TestEnv -> IO a) -> IO a
+withTestEnv action = do
+    dbPath <-
+        emptySystemTempFile "kel-circle-e2e-.db"
+    let sid = MemberId "server-sequencer"
+    ch <- newBroadcastTChanIO
+    (store :: CircleStore () () ()) <-
+        openStore
+            sid
+            ()
+            trivialAppFold
+            dbPath
+    let cfg =
+            ServerConfig
+                { scStore = store
+                , scAppFold = trivialAppFold
+                , scBaseAppGate = trivialBaseGate
+                , scAppGate = trivialAppGate
+                , scProposalGate =
+                    trivialProposalGate
+                , scPassphrase = testPass
+                , scBroadcast = ch
+                }
+    mgr <- HC.newManager HC.defaultManagerSettings
+    result <-
+        Warp.testWithApplication
+            (pure $ mkApp cfg)
+            ( \port ->
+                action
+                    TestEnv
+                        { tePort = port
+                        , teMgr = mgr
+                        }
+            )
+    closeStore store
+    removeFile dbPath
+    pure result
+
+-- | Trivial app fold: Unit state, no-op.
+trivialAppFold :: () -> () -> ()
+trivialAppFold _ _ = ()
+
+-- | Trivial base app gate: always passes.
+trivialBaseGate :: () -> BaseDecision -> Bool
+trivialBaseGate _ _ = True
+
+-- | Trivial app gate: always passes.
+trivialAppGate :: () -> () -> Bool
+trivialAppGate _ _ = True
+
+-- | Trivial proposal gate: always passes.
+trivialProposalGate :: () -> () -> Bool
+trivialProposalGate _ _ = True
+
+-- --------------------------------------------------------
+-- HTTP helpers
+-- --------------------------------------------------------
+
+-- | GET request to the test server.
+httpGet
+    :: TestEnv
+    -> String
+    -> IO (HC.Response LBS.ByteString)
+httpGet te path = do
+    req <-
+        HC.parseRequest $
+            "http://127.0.0.1:"
+                <> show (tePort te)
+                <> path
+    HC.httpLbs req (teMgr te)
+
+-- | POST request with JSON body.
+httpPost
+    :: TestEnv
+    -> String
+    -> LBS.ByteString
+    -> IO (HC.Response LBS.ByteString)
+httpPost te path body = do
+    initReq <-
+        HC.parseRequest $
+            "http://127.0.0.1:"
+                <> show (tePort te)
+                <> path
+    let req =
+            initReq
+                { HC.method = "POST"
+                , HC.requestBody =
+                    HC.RequestBodyLBS body
+                , HC.requestHeaders =
+                    [
+                        ( "Content-Type"
+                        , "application/json"
+                        )
+                    ]
+                }
+    HC.httpLbs req (teMgr te)
+
+{- | POST a test submission and expect 200.
+Returns the sequence number.
+-}
+postEvent :: TestEnv -> TestSub -> IO Int
+postEvent te ts = do
+    let sub = signSubmission ts
+    resp <- httpPost te "/events" (encode sub)
+    assertEqual
+        "POST /events status"
+        status200
+        (HC.responseStatus resp)
+    ar <- decodeOrFail (HC.responseBody resp)
+    pure (sequenceNumber ar)
+
+{- | POST a test submission and return the raw
+response (for testing error cases).
+-}
+postEventRaw
+    :: TestEnv
+    -> TestSub
+    -> IO (HC.Response LBS.ByteString)
+postEventRaw te ts = do
+    let sub = signSubmission ts
+    httpPost te "/events" (encode sub)
+
+-- | GET /info and decode.
+getInfo :: TestEnv -> IO InfoResp
+getInfo te = do
+    resp <- httpGet te "/info"
+    assertEqual
+        "GET /info status"
+        status200
+        (HC.responseStatus resp)
+    decodeOrFail (HC.responseBody resp)
+
+-- | GET /condition and decode.
+getCondition :: TestEnv -> IO ConditionResp
+getCondition te = do
+    resp <- httpGet te "/condition"
+    assertEqual
+        "GET /condition status"
+        status200
+        (HC.responseStatus resp)
+    decodeOrFail (HC.responseBody resp)
+
+-- | Decode JSON or fail the test.
+decodeOrFail
+    :: (FromJSON a) => LBS.ByteString -> IO a
+decodeOrFail bs = case decode bs of
+    Just x -> pure x
+    Nothing ->
+        error $
+            "JSON decode failed: "
+                <> show (LBS.take 200 bs)
+
+-- --------------------------------------------------------
+-- Unsigned test submissions
+-- --------------------------------------------------------
+
+-- | An unsigned test submission.
+data TestSub = TestSub
+    { tsSigner :: TestId
+    , tsPassphrase :: Maybe Text
+    , tsEvent :: CircleEvent () () ()
+    }
+
+{- | Sign a test submission. The signature is a
+dummy value for now (no real Ed25519). The server
+does not verify signatures in E2E tests.
+-}
+signSubmission :: TestSub -> Submission () () ()
+signSubmission ts =
+    Submission
+        { subPassphrase = tsPassphrase ts
+        , subSigner = tidKey (tsSigner ts)
+        , subSignature =
+            "sig:" <> tidKey (tsSigner ts)
+        , subEvent = tsEvent ts
+        }
+
+-- --------------------------------------------------------
+-- Submission builders
+-- --------------------------------------------------------
+
+-- | Bootstrap the first admin.
+bootstrapAdmin :: TestId -> TestSub
+bootstrapAdmin tid =
+    TestSub
+        { tsSigner = tid
+        , tsPassphrase = Just testPass
+        , tsEvent =
+            CEBaseDecision $
+                IntroduceMember
+                    (MemberId $ tidKey tid)
+                    Admin
+        }
+
+-- | Introduce a regular member.
+introduceMember :: TestId -> TestId -> TestSub
+introduceMember signer newMember =
+    TestSub
+        { tsSigner = signer
+        , tsPassphrase = Nothing
+        , tsEvent =
+            CEBaseDecision $
+                IntroduceMember
+                    (MemberId $ tidKey newMember)
+                    Member
+        }
+
+-- | Introduce a new admin.
+introduceAdmin :: TestId -> TestId -> TestSub
+introduceAdmin signer newAdmin =
+    TestSub
+        { tsSigner = signer
+        , tsPassphrase = Nothing
+        , tsEvent =
+            CEBaseDecision $
+                IntroduceMember
+                    (MemberId $ tidKey newAdmin)
+                    Admin
+        }
+
+-- | Remove a member.
+removeMember :: TestId -> TestId -> TestSub
+removeMember signer target =
+    TestSub
+        { tsSigner = signer
+        , tsPassphrase = Nothing
+        , tsEvent =
+            CEBaseDecision $
+                RemoveMember
+                    (MemberId $ tidKey target)
+        }
+
+-- | Change a member's role.
+changeRole
+    :: TestId -> TestId -> Role -> TestSub
+changeRole signer target role =
+    TestSub
+        { tsSigner = signer
+        , tsPassphrase = Nothing
+        , tsEvent =
+            CEBaseDecision $
+                ChangeRole
+                    (MemberId $ tidKey target)
+                    role
+        }
+
+-- | Submit a proposal (trivial Unit content).
+submitProposal
+    :: TestId -> Timestamp -> TestSub
+submitProposal signer deadline =
+    TestSub
+        { tsSigner = signer
+        , tsPassphrase = Nothing
+        , tsEvent = CEProposal () deadline
+        }
+
+-- | Respond to a proposal (trivial Unit content).
+respondToProposal
+    :: TestId -> ProposalId -> TestSub
+respondToProposal signer pid =
+    TestSub
+        { tsSigner = signer
+        , tsPassphrase = Nothing
+        , tsEvent = CEResponse () pid
+        }
+
+-- | Resolve a proposal (sequencer only).
+resolveProposal
+    :: TestId
+    -> ProposalId
+    -> Resolution
+    -> TestSub
+resolveProposal signer pid res =
+    TestSub
+        { tsSigner = signer
+        , tsPassphrase = Nothing
+        , tsEvent = CEResolveProposal pid res
+        }
+
+-- --------------------------------------------------------
+-- Response decoders
+-- --------------------------------------------------------
+
+-- | Decoded /info response.
+data InfoResp = InfoResp
+    { irAuthMode :: Text
+    , irMemberCount :: Int
+    , irNextSeq :: Int
+    }
+    deriving stock (Show)
+
+instance FromJSON InfoResp where
+    parseJSON = withObject "InfoResp" $ \o ->
+        InfoResp
+            <$> o .: "authMode"
+            <*> o .: "memberCount"
+            <*> o .: "nextSeq"
+
+-- | A member in the condition response.
+data ConditionMember = ConditionMember
+    { cmMemberId :: Text
+    , cmRole :: Text
+    }
+    deriving stock (Show)
+
+instance FromJSON ConditionMember where
+    parseJSON = withObject "ConditionMember" $ \o ->
+        ConditionMember
+            <$> o .: "memberId"
+            <*> o .: "role"
+
+-- | Decoded /condition response.
+data ConditionResp = ConditionResp
+    { crAuthMode :: Text
+    , crMembers :: [ConditionMember]
+    , crProposals :: [Value]
+    , crNextSeq :: Int
+    }
+    deriving stock (Show)
+
+instance FromJSON ConditionResp where
+    parseJSON = withObject "ConditionResp" $ \o ->
+        ConditionResp
+            <$> o .: "authMode"
+            <*> o .: "members"
+            <*> o .: "proposals"
+            <*> o .: "nextSeq"

--- a/test/E2EMain.hs
+++ b/test/E2EMain.hs
@@ -1,0 +1,19 @@
+{- |
+Module      : Main
+Description : E2E test entry point
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Runs all E2E scenarios through the HTTP API.
+-}
+module Main (main) where
+
+import E2E.Spec qualified
+import Test.Tasty (defaultMain, testGroup)
+
+main :: IO ()
+main =
+    defaultMain $
+        testGroup
+            "kel-circle-e2e"
+            [E2E.Spec.tests]


### PR DESCRIPTION
## Summary

- **Server infrastructure**: `KelCircle.Server.JSON` (Aeson instances + HTTP types), `KelCircle.Store` (SQLite-backed global sequence with TVar hot state), `KelCircle.Server` (WAI application with REST + SSE endpoints)
- **15 E2E tests** exercising the full circle lifecycle via HTTP: bootstrap, member management, role change rejection, proposals, resolution, re-bootstrap, event replay
- All 53 unit tests + 15 E2E tests + Lean proofs + docs pass CI

## Test plan

- [x] `just ci` passes locally (format, lint, build, test, lean, docs)
- [x] 15 E2E scenarios cover bootstrap, member ops, proposals, auth edge cases
- [x] 53 unit tests still pass
- [x] Lean proofs still compile