### PR TITLE
feat: docker image build+push CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/paolino/kel-circle
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Build docker image with nix
+        run: nix build --quiet .#docker-image -o result
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Load and push image
+        run: |
+          docker load < result
+          TAG=$(docker images "$IMAGE" --format '{{.Tag}}' | head -1)
+          echo "Loaded image tag: $TAG"
+          docker tag "$IMAGE:$TAG" "$IMAGE:latest"
+          docker push "$IMAGE:$TAG"
+          docker push "$IMAGE:latest"

--- a/justfile
+++ b/justfile
@@ -74,6 +74,15 @@ restart port="8080" db="kel-circle.db" pass="bootstrap": bundle-client
     -pkill -f "kel-circle-server"
     cabal run kel-circle-server -O0 -- {{port}} {{db}} {{pass}}
 
+# Build docker image via nix
+docker:
+    nix build --quiet .#docker-image -o result
+    @echo "Image tarball: ./result"
+
+# Load docker image locally
+docker-load: docker
+    docker load < result
+
 # Clean build artifacts
 clean:
     cabal clean


### PR DESCRIPTION
## Summary
- Add `.github/workflows/docker.yml` to build and push docker image on every push to main
- Uses nix `docker-image` flake output, pushes to `ghcr.io/paolino/kel-circle`
- Tags with both commit hash and `latest`
- Add `docker` and `docker-load` just recipes for local builds

## Test plan
- [ ] CI workflow triggers on merge to main
- [ ] Image appears at ghcr.io/paolino/kel-circle
- [ ] `just docker-load` works locally