### PR TITLE
feat: kel-circle-server executable

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,0 +1,93 @@
+{- |
+Module      : Main
+Description : kel-circle-server executable
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+HTTP server for the kel-circle trivial application.
+Uses Unit types for all application parameters.
+-}
+module Main (main) where
+
+import Control.Concurrent.STM
+    ( newBroadcastTChanIO
+    )
+import Control.Exception (bracket)
+import Data.Text (Text, pack)
+import KelCircle.Events (BaseDecision)
+import KelCircle.Server (ServerConfig (..), mkApp)
+import KelCircle.Store
+    ( CircleStore
+    , closeStore
+    , openStore
+    )
+import KelCircle.Types (MemberId (..))
+import Network.Wai.Application.Static
+    ( defaultFileServerSettings
+    , staticApp
+    )
+import Network.Wai.Handler.Warp qualified as Warp
+import System.Environment (getArgs)
+
+-- | Entry point: parse args and run server.
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+        [portStr, dbPath, pass] ->
+            let port = read portStr
+            in  runServer port dbPath (pack pass)
+        _ ->
+            putStrLn
+                "Usage: kel-circle-server \
+                \<port> <db> <pass>"
+
+-- | Run the HTTP server with trivial application.
+runServer :: Int -> FilePath -> Text -> IO ()
+runServer port dbPath passphrase =
+    bracket
+        (openStore sid () trivialAppFold dbPath)
+        closeStore
+        $ \(store :: CircleStore () () ()) -> do
+            ch <- newBroadcastTChanIO
+            let cfg =
+                    ServerConfig
+                        { scStore = store
+                        , scAppFold = trivialAppFold
+                        , scBaseAppGate =
+                            trivialBaseGate
+                        , scAppGate = trivialAppGate
+                        , scProposalGate =
+                            trivialProposalGate
+                        , scPassphrase = passphrase
+                        , scBroadcast = ch
+                        }
+                staticDir =
+                    "client/kel-circle-trivial/dist"
+                fallback =
+                    staticApp
+                        ( defaultFileServerSettings
+                            staticDir
+                        )
+                app = mkApp cfg (Just fallback)
+            putStrLn $
+                "Listening on port " <> show port
+            Warp.run port app
+  where
+    sid = MemberId "server-sequencer"
+
+-- | Trivial app fold: Unit state, no-op.
+trivialAppFold :: () -> () -> ()
+trivialAppFold _ _ = ()
+
+-- | Trivial base app gate: always passes.
+trivialBaseGate :: () -> BaseDecision -> Bool
+trivialBaseGate _ _ = True
+
+-- | Trivial app gate: always passes.
+trivialAppGate :: () -> () -> Bool
+trivialAppGate _ _ = True
+
+-- | Trivial proposal gate: always passes.
+trivialProposalGate :: () -> () -> Bool
+trivialProposalGate _ _ = True

--- a/justfile
+++ b/justfile
@@ -12,11 +12,11 @@ e2e:
 
 # Format Haskell sources
 format:
-    fourmolu -i lib/**/*.hs lib/KelCircle.hs test/Main.hs test/E2EMain.hs test/KelCircle/Test/*.hs test/E2E/*.hs
+    fourmolu -i lib/**/*.hs lib/KelCircle.hs app/Main.hs test/Main.hs test/E2EMain.hs test/KelCircle/Test/*.hs test/E2E/*.hs
 
 # Lint Haskell sources
 lint:
-    hlint lib/ test/
+    hlint lib/ app/ test/
 
 # Format cabal file
 cabal-fmt:
@@ -51,7 +51,7 @@ ci: format-check lint build test lean build-docs
 
 # Check Haskell formatting (no modification)
 format-check:
-    fourmolu --mode check lib/**/*.hs lib/KelCircle.hs test/Main.hs test/E2EMain.hs test/KelCircle/Test/*.hs test/E2E/*.hs
+    fourmolu --mode check lib/**/*.hs lib/KelCircle.hs app/Main.hs test/Main.hs test/E2EMain.hs test/KelCircle/Test/*.hs test/E2E/*.hs
 
 # Build documentation
 build-docs:

--- a/kel-circle.cabal
+++ b/kel-circle.cabal
@@ -66,6 +66,19 @@ library
     , text           >=2.0  && <3
     , wai            >=3.2  && <4
 
+executable kel-circle-server
+  import:         language, opts-lib
+  hs-source-dirs: app
+  main-is:        Main.hs
+  ghc-options:    -threaded
+  build-depends:
+    , base            >=4.18 && <5
+    , kel-circle
+    , stm             >=2.5  && <3
+    , text            >=2.0  && <3
+    , wai-app-static  >=3.1  && <4
+    , warp            >=3.3  && <4
+
 test-suite unit-tests
   import:         language, opts-test
   type:           exitcode-stdio-1.0

--- a/test/E2E/TestHelpers.hs
+++ b/test/E2E/TestHelpers.hs
@@ -171,7 +171,7 @@ withTestEnv action = do
     mgr <- HC.newManager HC.defaultManagerSettings
     result <-
         Warp.testWithApplication
-            (pure $ mkApp cfg)
+            (pure $ mkApp cfg Nothing)
             ( \port ->
                 action
                     TestEnv


### PR DESCRIPTION
## Summary
- Add `executable kel-circle-server` in cabal with trivial app types (Unit for d, p, r)
- Create `app/Main.hs` with SQLite-backed server, static file serving for PureScript client
- Add optional `Maybe Application` fallback to `mkApp` for unmatched routes
- Update justfile format/lint globs to include `app/`

## Test plan
- [x] 53 unit tests pass
- [x] 15 E2E tests pass
- [x] fourmolu + hlint clean
- [ ] Docker image builds via `nix build .#docker-image`