### PR TITLE
feat: per-member KEL storage and inception validation

### DIFF
--- a/kel-circle.cabal
+++ b/kel-circle.cabal
@@ -47,6 +47,7 @@ library
     KelCircle.Events
     KelCircle.Fold
     KelCircle.Gate
+    KelCircle.MemberKel
     KelCircle.Processing
     KelCircle.Proposals
     KelCircle.Sequence
@@ -61,11 +62,13 @@ library
     , aeson          >=2.1  && <3
     , base           >=4.18 && <5
     , bytestring     >=0.11 && <1
+    , containers     >=0.6  && <1
     , http-types     >=0.12 && <1
     , keri-hs
     , sqlite-simple  >=0.4  && <1
     , stm            >=2.5  && <3
     , text           >=2.0  && <3
+    , vector         >=0.12 && <1
     , wai            >=3.2  && <4
 
 executable kel-circle-server
@@ -91,11 +94,13 @@ test-suite unit-tests
     KelCircle.Test.Crypto
     KelCircle.Test.Gate
     KelCircle.Test.Generators
+    KelCircle.Test.MemberKel
     KelCircle.Test.Processing
     KelCircle.Test.Proposals
     KelCircle.Test.Sequence
 
   build-depends:
+    , aeson             >=2.1  && <3
     , base              >=4.18 && <5
     , kel-circle
     , keri-hs

--- a/lean/KelCircle.lean
+++ b/lean/KelCircle.lean
@@ -9,4 +9,5 @@ import KelCircle.Fold
 import KelCircle.Invariants
 import KelCircle.BaseDecisions
 import KelCircle.Proposals
+import KelCircle.MemberKel
 import KelCircle.Processing

--- a/lean/KelCircle/MemberKel.lean
+++ b/lean/KelCircle/MemberKel.lean
@@ -1,0 +1,138 @@
+-- MemberKel: per-member KEL storage invariants
+--
+-- Each introduced member has a Key Event Log (KEL) starting with
+-- an inception event. The memberKels map tracks these logs.
+-- Key invariants: every circle member has a KEL entry, and
+-- KEL owner IDs match member IDs.
+
+import KelCircle.Events
+
+namespace KelCircle
+
+-------------------------------------------------------------------
+-- Abstract KEL model
+-------------------------------------------------------------------
+
+-- A member's KEL: owner ID + event count (at least 1 for inception)
+structure MemberKel where
+  ownerId : MemberId
+  eventCount : Nat
+  deriving Repr, DecidableEq
+
+-- The map from member IDs to their KELs
+abbrev MemberKels := List (MemberId × MemberKel)
+
+-------------------------------------------------------------------
+-- Core invariants
+-------------------------------------------------------------------
+
+-- Every circle member has a KEL entry
+def allMembersHaveKel
+    (members : List Member) (kels : MemberKels) : Prop :=
+  ∀ m, m ∈ members → ∃ k, k ∈ kels ∧ k.1 = m.id
+
+-- KEL owner matches the member ID key
+def kelOwnersMatch (kels : MemberKels) : Prop :=
+  ∀ k, k ∈ kels → k.2.ownerId = k.1
+
+-- A KEL has at least one event (the inception)
+def kelNonEmpty (kels : MemberKels) : Prop :=
+  ∀ k, k ∈ kels → k.2.eventCount ≥ 1
+
+-------------------------------------------------------------------
+-- Operations
+-------------------------------------------------------------------
+
+-- Insert a new KEL entry (inception creates a KEL with 1 event)
+def insertKel (kels : MemberKels) (mid : MemberId)
+    : MemberKels :=
+  (mid, ⟨mid, 1⟩) :: kels
+
+-- Remove a KEL entry
+def removeKel (kels : MemberKels) (mid : MemberId)
+    : MemberKels :=
+  kels.filter (fun k => decide (k.1 ≠ mid))
+
+-- Look up a KEL by member ID
+def lookupKel (kels : MemberKels) (mid : MemberId)
+    : Option MemberKel :=
+  match kels.find? (fun k => decide (k.1 = mid)) with
+  | some k => some k.2
+  | none => none
+
+-------------------------------------------------------------------
+-- Preservation theorems
+-------------------------------------------------------------------
+
+-- Inserting a KEL preserves allMembersHaveKel for existing members
+theorem insert_preserves_allMembersHaveKel
+    (members : List Member) (kels : MemberKels)
+    (mid : MemberId)
+    (h : allMembersHaveKel members kels) :
+    allMembersHaveKel members (insertKel kels mid) := by
+  intro m hm
+  obtain ⟨k, hk, heq⟩ := h m hm
+  exact ⟨k, .tail _ hk, heq⟩
+
+-- After inserting member + KEL, the new member has a KEL
+theorem insert_new_member_has_kel
+    (kels : MemberKels) (mid : MemberId) :
+    ∃ k, k ∈ insertKel kels mid ∧ k.1 = mid := by
+  exact ⟨(mid, ⟨mid, 1⟩), .head _, rfl⟩
+
+-- Introducing member + KEL atomically preserves the invariant
+theorem introduce_with_kel_preserves_allMembersHaveKel
+    (members : List Member) (kels : MemberKels)
+    (newMem : Member)
+    (h : allMembersHaveKel members kels) :
+    allMembersHaveKel (newMem :: members)
+      (insertKel kels newMem.id) := by
+  intro m hm
+  cases hm with
+  | head => exact insert_new_member_has_kel kels newMem.id
+  | tail _ hm' =>
+    obtain ⟨k, hk, heq⟩ := h m hm'
+    exact ⟨k, .tail _ hk, heq⟩
+
+-- Removing member + KEL preserves invariant for remaining members
+theorem remove_member_preserves_allMembersHaveKel
+    (members : List Member) (kels : MemberKels)
+    (mid : MemberId)
+    (h : allMembersHaveKel members kels)
+    (hmem : ∀ m, m ∈ members → m.id ≠ mid) :
+    allMembersHaveKel members (removeKel kels mid) := by
+  intro m hm_in
+  obtain ⟨k, hk, heq⟩ := h m hm_in
+  have hne : k.1 ≠ mid := by rw [heq]; exact hmem m hm_in
+  exact ⟨k, List.mem_filter.mpr ⟨hk, decide_eq_true hne⟩, heq⟩
+
+-- insertKel preserves kelOwnersMatch
+theorem insert_preserves_kelOwnersMatch
+    (kels : MemberKels) (mid : MemberId)
+    (h : kelOwnersMatch kels) :
+    kelOwnersMatch (insertKel kels mid) := by
+  intro k hk
+  cases hk with
+  | head => rfl
+  | tail _ hk' => exact h k hk'
+
+-- insertKel preserves kelNonEmpty
+theorem insert_preserves_kelNonEmpty
+    (kels : MemberKels) (mid : MemberId)
+    (h : kelNonEmpty kels) :
+    kelNonEmpty (insertKel kels mid) := by
+  intro k hk
+  cases hk with
+  | head => simp
+  | tail _ hk' => exact h k hk'
+
+-------------------------------------------------------------------
+-- Non-membership events don't affect KELs
+-------------------------------------------------------------------
+
+-- These theorems are proven in Processing.lean where the
+-- apply functions are defined. The key property is that
+-- applyBase, applyAppDecision, applyProposal, applyResponse,
+-- and applyResolve all preserve the memberKels field.
+
+end KelCircle

--- a/lib/KelCircle/MemberKel.hs
+++ b/lib/KelCircle/MemberKel.hs
@@ -1,0 +1,283 @@
+{- |
+Module      : KelCircle.MemberKel
+Description : Per-member KEL storage and inception validation
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Validates inception events for new circle members and
+manages per-member Key Event Logs. Each introduced member
+must provide a signed inception event at introduction time.
+-}
+module KelCircle.MemberKel
+    ( -- * KEL types
+      MemberKel (..)
+    , KelEvent (..)
+    , kelEventCount
+
+      -- * Inception parsing
+    , InceptionSubmission (..)
+    , parseInceptionValue
+
+      -- * Validation
+    , validateInception
+
+      -- * KEL construction
+    , kelFromInception
+    ) where
+
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    , Value (..)
+    , decodeStrict
+    , object
+    , withObject
+    , (.:)
+    , (.=)
+    )
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KM
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Data.Vector qualified as V
+import KelCircle.Types (MemberId (..))
+import Keri.Cesr.Decode qualified as Cesr
+import Keri.Cesr.DerivationCode (DerivationCode (..))
+import Keri.Cesr.Primitive (Primitive (..))
+import Keri.KeyState.Verify (verifySignatures)
+
+-- --------------------------------------------------------
+-- KEL types
+-- --------------------------------------------------------
+
+-- | A single stored KEL event.
+data KelEvent = KelEvent
+    { keEventBytes :: ByteString
+    -- ^ Canonical KERI JSON serialization
+    , keSignatures :: [(Int, Text)]
+    -- ^ Indexed CESR-encoded signatures
+    }
+    deriving stock (Show, Eq)
+
+-- | A member's Key Event Log.
+newtype MemberKel = MemberKel
+    { mkelEvents :: [KelEvent]
+    }
+    deriving stock (Show, Eq)
+
+-- | Number of events in a member's KEL.
+kelEventCount :: MemberKel -> Int
+kelEventCount = length . mkelEvents
+
+-- --------------------------------------------------------
+-- Inception submission parsing
+-- --------------------------------------------------------
+
+{- | Parsed inception submission from the client.
+The event is the canonical KERI JSON as a text string,
+and signatures are indexed CESR-encoded Ed25519 signatures.
+-}
+data InceptionSubmission = InceptionSubmission
+    { isEventText :: Text
+    -- ^ Canonical KERI event JSON as string
+    , isSignatures :: [(Int, Text)]
+    -- ^ Indexed CESR signatures
+    }
+    deriving stock (Show, Eq)
+
+instance FromJSON InceptionSubmission where
+    parseJSON = withObject "InceptionSubmission" $ \o ->
+        InceptionSubmission
+            <$> o .: "event"
+            <*> o .: "signatures"
+
+instance ToJSON InceptionSubmission where
+    toJSON is =
+        object
+            [ "event" .= isEventText is
+            , "signatures" .= isSignatures is
+            ]
+
+{- | Parse an inception 'Value' into an
+'InceptionSubmission'.
+-}
+parseInceptionValue
+    :: Value -> Either Text InceptionSubmission
+parseInceptionValue val =
+    case Aeson.fromJSON val of
+        Aeson.Success is -> Right is
+        Aeson.Error err -> Left $ T.pack err
+
+-- --------------------------------------------------------
+-- Validation
+-- --------------------------------------------------------
+
+{- | Validate a parsed inception event for a member.
+
+Checks:
+
+1. Event bytes are valid JSON
+2. Event type is @\"icp\"@ (inception)
+3. Sequence number (@\"s\"@ field) is @\"0\"@
+4. Member key is present in inception signing keys
+5. Signatures verify against the event keys
+
+Returns @Right ()@ on success, @Left reason@ on failure.
+-}
+validateInception
+    :: MemberId
+    -> InceptionSubmission
+    -> Either Text ()
+validateInception
+    (MemberId memberKey)
+    (InceptionSubmission eventText sigs) = do
+        let eventBytes = TE.encodeUtf8 eventText
+        obj <- parseEventJson eventBytes
+        validateEventType obj
+        validateSeqNum obj
+        keys <- extractKeys obj
+        validateKeyPresent keys memberKey
+        threshold <- extractThreshold obj
+        validateSignatureCesr sigs
+        verifySigs keys threshold eventBytes sigs
+
+-- --------------------------------------------------------
+-- Internal validation helpers
+-- --------------------------------------------------------
+
+-- | Parse event bytes as a JSON object.
+parseEventJson :: ByteString -> Either Text Value
+parseEventJson bs =
+    case decodeStrict bs of
+        Just v@(Object _) -> Right v
+        Just _ -> Left "event is not a JSON object"
+        Nothing -> Left "event is not valid JSON"
+
+-- | Check event type is \"icp\".
+validateEventType :: Value -> Either Text ()
+validateEventType val =
+    case lookupField "t" val of
+        Just (String "icp") -> Right ()
+        Just (String t) ->
+            Left $
+                "expected event type icp, got: "
+                    <> t
+        _ -> Left "missing or invalid event type"
+
+-- | Check member key is in the inception keys.
+validateKeyPresent
+    :: [Text] -> Text -> Either Text ()
+validateKeyPresent keys memberKey
+    | memberKey `elem` keys = Right ()
+    | otherwise =
+        Left "member key not in inception keys"
+
+-- | Check sequence number is \"0\".
+validateSeqNum :: Value -> Either Text ()
+validateSeqNum val =
+    case lookupField "s" val of
+        Just (String "0") -> Right ()
+        Just (String s) ->
+            Left $
+                "expected sequence 0, got: " <> s
+        _ ->
+            Left "missing or invalid sequence number"
+
+-- | Validate that all signatures are valid CESR.
+validateSignatureCesr
+    :: [(Int, Text)] -> Either Text ()
+validateSignatureCesr sigs
+    | null sigs = Left "no signatures provided"
+    | otherwise = mapM_ checkSig sigs
+  where
+    checkSig (_, sigText) =
+        case Cesr.decode sigText of
+            Left err ->
+                Left $
+                    "invalid CESR signature: "
+                        <> T.pack err
+            Right prim
+                | code prim /= Ed25519Sig ->
+                    Left
+                        "signature is not Ed25519"
+                | BS.length (raw prim) /= 64 ->
+                    Left
+                        "signature has wrong length"
+                | otherwise -> Right ()
+
+-- | Extract signing keys from the event.
+extractKeys :: Value -> Either Text [Text]
+extractKeys val =
+    case lookupField "k" val of
+        Just (Array arr) ->
+            Right [t | String t <- V.toList arr]
+        _ -> Left "missing or invalid keys field"
+
+-- | Extract signing threshold from the event.
+extractThreshold :: Value -> Either Text Int
+extractThreshold val =
+    case lookupField "kt" val of
+        Just (String t) ->
+            case reads (T.unpack t) of
+                [(n, "")] -> Right n
+                _ ->
+                    Left $
+                        "invalid threshold: " <> t
+        Just (Number n) -> Right (round n)
+        _ ->
+            Left "missing or invalid threshold field"
+
+-- | Verify signatures using keri-hs.
+verifySigs
+    :: [Text]
+    -> Int
+    -> ByteString
+    -> [(Int, Text)]
+    -> Either Text ()
+verifySigs keys threshold eventBytes sigs =
+    case verifySignatures
+        keys
+        threshold
+        eventBytes
+        sigs of
+        Left err ->
+            Left $
+                "signature verification failed: "
+                    <> T.pack err
+        Right False ->
+            Left "signature threshold not met"
+        Right True -> Right ()
+
+-- --------------------------------------------------------
+-- KEL construction
+-- --------------------------------------------------------
+
+{- | Create a 'MemberKel' from a validated inception.
+Call 'validateInception' first.
+-}
+kelFromInception
+    :: InceptionSubmission -> MemberKel
+kelFromInception (InceptionSubmission eventText sigs) =
+    MemberKel
+        { mkelEvents =
+            [ KelEvent
+                { keEventBytes =
+                    TE.encodeUtf8 eventText
+                , keSignatures = sigs
+                }
+            ]
+        }
+
+-- --------------------------------------------------------
+-- JSON field lookup helper
+-- --------------------------------------------------------
+
+-- | Look up a field in a JSON object by text key.
+lookupField :: Text -> Value -> Maybe Value
+lookupField key (Object o) =
+    KM.lookup (Key.fromText key) o
+lookupField _ _ = Nothing

--- a/lib/KelCircle/Processing.hs
+++ b/lib/KelCircle/Processing.hs
@@ -28,11 +28,14 @@ module KelCircle.Processing
     , applyResolve
     ) where
 
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import KelCircle.Events
     ( BaseDecision (..)
     , Resolution
     )
 import KelCircle.Gate (fullGate)
+import KelCircle.MemberKel (MemberKel)
 import KelCircle.Proposals qualified as P
 import KelCircle.State
     ( Circle (..)
@@ -65,6 +68,8 @@ data FullState g p r = FullState
     -- ^ Tracked proposals
     , fsNextSeq :: Int
     -- ^ Next sequence number
+    , fsMemberKels :: Map MemberId MemberKel
+    -- ^ Per-member Key Event Logs
     }
     deriving stock (Show, Eq)
 
@@ -80,6 +85,7 @@ initFullState sid initApp =
         , fsAppState = initApp
         , fsProposals = []
         , fsNextSeq = 1
+        , fsMemberKels = Map.empty
         }
   where
     genesis sid' =

--- a/lib/KelCircle/Server/JSON.hs
+++ b/lib/KelCircle/Server/JSON.hs
@@ -60,6 +60,8 @@ data Submission d p r = Submission
     -- ^ CESR-encoded Ed25519 signature
     , subEvent :: CircleEvent d p r
     -- ^ The event to append
+    , subInception :: Maybe Value
+    -- ^ Signed inception event (required for IntroduceMember)
     }
     deriving stock (Show, Eq)
 
@@ -332,6 +334,19 @@ instance ToJSON ValidationError where
             , "memberId" .= mid
             , "reason" .= reason
             ]
+    toJSON (MissingInception mid) =
+        object
+            [ "error"
+                .= ("missingInception" :: Text)
+            , "memberId" .= mid
+            ]
+    toJSON (InvalidInception mid reason) =
+        object
+            [ "error"
+                .= ("invalidInception" :: Text)
+            , "memberId" .= mid
+            , "reason" .= reason
+            ]
 
 -- --------------------------------------------------------
 -- Submission
@@ -347,6 +362,7 @@ instance
             , "signer" .= subSigner s
             , "signature" .= subSignature s
             , "event" .= subEvent s
+            , "inception" .= subInception s
             ]
 
 instance
@@ -359,6 +375,7 @@ instance
             <*> o .: "signer"
             <*> o .: "signature"
             <*> o .: "event"
+            <*> o .:? "inception"
 
 -- --------------------------------------------------------
 -- AppendResult

--- a/lib/KelCircle/Store.hs
+++ b/lib/KelCircle/Store.hs
@@ -8,6 +8,9 @@ Persistent append-only store for the global sequence,
 backed by SQLite. Each event is stored as JSON along
 with the signer key and Ed25519 signature. The server
 maintains a hot @FullState@ in a @TVar@ for O(1) reads.
+
+Per-member KELs are stored in a separate @member_kels@
+table and rebuilt on replay.
 -}
 module KelCircle.Store
     ( -- * Store handle
@@ -37,7 +40,10 @@ import Control.Concurrent.STM
     )
 import Data.Aeson (FromJSON, ToJSON, decode, encode)
 import Data.ByteString.Lazy qualified as LBS
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
+import Data.Text.Encoding qualified as TE
 import Database.SQLite.Simple
     ( Connection
     , Only (..)
@@ -48,7 +54,14 @@ import Database.SQLite.Simple
     , query
     , query_
     )
-import KelCircle.Events (CircleEvent (..))
+import KelCircle.Events
+    ( BaseDecision (..)
+    , CircleEvent (..)
+    )
+import KelCircle.MemberKel
+    ( KelEvent (..)
+    , MemberKel (..)
+    )
 import KelCircle.Processing
     ( FullState (..)
     , applyAppDecision
@@ -85,8 +98,8 @@ data CircleStore g p r = CircleStore
     }
 
 {- | Open or create a circle store at the given path.
-Creates the events table on first open and replays
-existing events to rebuild the in-memory state.
+Creates the events and member_kels tables on first open
+and replays existing events to rebuild the in-memory state.
 -}
 openStore
     :: ( FromJSON d
@@ -103,6 +116,7 @@ openStore
     -> IO (CircleStore g p r)
 openStore sid initApp appFold path = do
     conn <- open path
+    -- Create events table
     execute_
         conn
         "CREATE TABLE IF NOT EXISTS events \
@@ -110,6 +124,16 @@ openStore sid initApp appFold path = do
         \, signer TEXT NOT NULL \
         \, event_json TEXT NOT NULL \
         \, signature TEXT NOT NULL \
+        \)"
+    -- Create member KELs table
+    execute_
+        conn
+        "CREATE TABLE IF NOT EXISTS member_kels \
+        \( member_id TEXT NOT NULL \
+        \, seq_num INTEGER NOT NULL \
+        \, event_json TEXT NOT NULL \
+        \, signatures_json TEXT NOT NULL \
+        \, PRIMARY KEY (member_id, seq_num) \
         \)"
     -- Replay events to rebuild state
     rows <-
@@ -119,11 +143,23 @@ openStore sid initApp appFold path = do
             \ORDER BY id"
             :: IO [(Text, LBS.ByteString)]
     let initialState = initFullState sid initApp
-        finalState =
+        circleState =
             foldl
                 (replayRow appFold)
                 initialState
                 rows
+    -- Replay member KELs
+    kelRows <-
+        query_
+            conn
+            "SELECT member_id, seq_num, event_json \
+            \, signatures_json \
+            \FROM member_kels ORDER BY member_id \
+            \, seq_num"
+            :: IO [(Text, Int, Text, LBS.ByteString)]
+    let kels = replayKelRows kelRows
+        finalState =
+            circleState{fsMemberKels = kels}
     stVar <- newTVarIO finalState
     [Only n] <-
         query_
@@ -144,6 +180,9 @@ closeStore = close . csConn
 {- | Append a verified event. Persists to SQLite and
 updates the in-memory state. The caller is responsible
 for validation before calling this.
+
+When the event is 'IntroduceMember', the optional
+'MemberKel' is inserted into the member_kels table.
 -}
 appendCircleEvent
     :: (ToJSON d, ToJSON p, ToJSON r)
@@ -156,23 +195,47 @@ appendCircleEvent
     -- ^ Signature
     -> CircleEvent d p r
     -- ^ The event to store
+    -> Maybe (MemberId, MemberKel)
+    -- ^ Optional: member KEL for IntroduceMember
     -> IO Int
-appendCircleEvent store appFold signer sig evt = do
-    let eventJson = encode evt
-    execute
-        (csConn store)
-        "INSERT INTO events \
-        \(signer, event_json, signature) \
-        \VALUES (?, ?, ?)"
-        (signer, eventJson, sig)
-    atomically $ do
-        st <- readTVar (csState store)
-        writeTVar (csState store) $
-            applyEvent appFold st (MemberId signer) evt
-        n <- readTVar (csLength store)
-        let n' = n + 1
-        writeTVar (csLength store) n'
-        pure n'
+appendCircleEvent store appFold signer sig evt mKel =
+    do
+        let eventJson = encode evt
+        -- Persist circle event
+        execute
+            (csConn store)
+            "INSERT INTO events \
+            \(signer, event_json, signature) \
+            \VALUES (?, ?, ?)"
+            (signer, eventJson, sig)
+        -- Persist member KEL if provided
+        case mKel of
+            Just (mid, kel) ->
+                storeMemberKelEvents
+                    (csConn store)
+                    mid
+                    kel
+            Nothing -> pure ()
+        -- Delete KEL on member removal
+        case evt of
+            CEBaseDecision (RemoveMember mid) ->
+                deleteMemberKel (csConn store) mid
+            _ -> pure ()
+        -- Update in-memory state
+        atomically $ do
+            st <- readTVar (csState store)
+            let st' =
+                    applyEvent
+                        appFold
+                        st
+                        (MemberId signer)
+                        evt
+                st'' = updateKels evt mKel st'
+            writeTVar (csState store) st''
+            n <- readTVar (csLength store)
+            let n' = n + 1
+            writeTVar (csLength store) n'
+            pure n'
 
 -- | Read current full state (from TVar, O(1)).
 readFullState :: CircleStore g p r -> IO (FullState g p r)
@@ -195,11 +258,11 @@ readEventsFrom store n = do
             :: IO [(Text, LBS.ByteString, Text)]
     pure $ map toStoredEvent rows
   where
-    toStoredEvent (s, ej, sig) =
+    toStoredEvent (s, ej, sig') =
         StoredEvent
             { seSigner = s
             , seEventJson = ej
-            , seSignature = sig
+            , seSignature = sig'
             }
 
 -- | Number of events in the store.
@@ -246,3 +309,77 @@ replayRow appFold st (signer, eventJson) =
                 (MemberId signer)
                 evt
         Nothing -> st
+
+-- | Rebuild member KELs from database rows.
+replayKelRows
+    :: [(Text, Int, Text, LBS.ByteString)]
+    -> Map.Map MemberId MemberKel
+replayKelRows = foldl addKelRow Map.empty
+  where
+    addKelRow acc (midText, _seqNum, evtJson, sigsJson) =
+        let mid = MemberId midText
+            evtBytes = TE.encodeUtf8 evtJson
+            sigs = fromMaybe [] (decode sigsJson)
+            ke =
+                KelEvent
+                    { keEventBytes = evtBytes
+                    , keSignatures = sigs
+                    }
+            existing =
+                Map.findWithDefault
+                    (MemberKel [])
+                    mid
+                    acc
+            updated =
+                MemberKel
+                    (mkelEvents existing ++ [ke])
+        in  Map.insert mid updated acc
+
+-- | Store all events in a member KEL.
+storeMemberKelEvents
+    :: Connection -> MemberId -> MemberKel -> IO ()
+storeMemberKelEvents conn (MemberId mid) kel =
+    mapM_ storeOne (zip [0 ..] (mkelEvents kel))
+  where
+    storeOne (seqNum, ke) =
+        execute
+            conn
+            "INSERT OR REPLACE INTO member_kels \
+            \(member_id, seq_num, event_json \
+            \, signatures_json) VALUES (?, ?, ?, ?)"
+            ( mid
+            , seqNum :: Int
+            , TE.decodeUtf8 (keEventBytes ke)
+            , encode (keSignatures ke)
+            )
+
+-- | Delete all KEL events for a member.
+deleteMemberKel
+    :: Connection -> MemberId -> IO ()
+deleteMemberKel conn (MemberId mid) =
+    execute
+        conn
+        "DELETE FROM member_kels WHERE member_id = ?"
+        (Only mid)
+
+-- | Update memberKels in the FullState.
+updateKels
+    :: CircleEvent d p r
+    -> Maybe (MemberId, MemberKel)
+    -> FullState g p r
+    -> FullState g p r
+updateKels evt mKel st = case mKel of
+    Just (mid, kel) ->
+        st
+            { fsMemberKels =
+                Map.insert mid kel (fsMemberKels st)
+            }
+    Nothing -> case evt of
+        CEBaseDecision (RemoveMember mid) ->
+            st
+                { fsMemberKels =
+                    Map.delete
+                        mid
+                        (fsMemberKels st)
+                }
+        _ -> st

--- a/lib/KelCircle/Validate.hs
+++ b/lib/KelCircle/Validate.hs
@@ -51,6 +51,10 @@ data ValidationError
       NotSequencer MemberId
     | -- | MemberId is not a valid CESR Ed25519 prefix
       InvalidMemberId MemberId Text
+    | -- | IntroduceMember without inception event
+      MissingInception MemberId
+    | -- | Inception event validation failed
+      InvalidInception MemberId Text
     deriving stock (Show, Eq)
 
 -- | Validate a base decision submission.

--- a/test/KelCircle/Test/MemberKel.hs
+++ b/test/KelCircle/Test/MemberKel.hs
@@ -1,0 +1,212 @@
+{- |
+Module      : KelCircle.Test.MemberKel
+Description : Unit tests for inception validation
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Tests for CESR inception validation, including
+valid inception, wrong prefix, bad signature, and
+non-inception event rejection.
+-}
+module KelCircle.Test.MemberKel (tests) where
+
+import Data.Aeson (Value, object, (.=))
+import Data.Either (isLeft, isRight)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import KelCircle.MemberKel
+    ( InceptionSubmission (..)
+    , kelEventCount
+    , kelFromInception
+    , parseInceptionValue
+    , validateInception
+    )
+import KelCircle.Types (MemberId (..))
+import Keri.Cesr.DerivationCode (DerivationCode (..))
+import Keri.Cesr.Encode qualified as Cesr
+import Keri.Cesr.Primitive (Primitive (..))
+import Keri.Crypto.Ed25519
+    ( KeyPair (..)
+    , generateKeyPair
+    , publicKeyBytes
+    , sign
+    )
+import Keri.Event.Inception
+    ( InceptionConfig (..)
+    , mkInception
+    )
+import Keri.Event.Serialize (serializeEvent)
+import Keri.KeyState.PreRotation (commitKey)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, testCase, (@?=))
+
+-- | All member KEL unit tests.
+tests :: TestTree
+tests =
+    testGroup
+        "MemberKel"
+        [ testValidateInception
+        , testKelFromInception
+        ]
+
+-- --------------------------------------------------------
+-- Test helpers
+-- --------------------------------------------------------
+
+-- | Create a proper inception submission for a keypair.
+mkTestInception
+    :: KeyPair -> IO (InceptionSubmission, Text)
+mkTestInception kp = do
+    let cesrKey =
+            Cesr.encode $
+                Primitive
+                    { code = Ed25519PubKey
+                    , raw =
+                        publicKeyBytes (publicKey kp)
+                    }
+    -- Next key for pre-rotation
+    nextKp <- generateKeyPair
+    let nextCesr =
+            Cesr.encode $
+                Primitive
+                    { code = Ed25519PubKey
+                    , raw =
+                        publicKeyBytes
+                            (publicKey nextKp)
+                    }
+    case commitKey nextCesr of
+        Left err -> error $ "commitKey: " <> err
+        Right commitment -> do
+            let cfg =
+                    InceptionConfig
+                        { icKeys = [cesrKey]
+                        , icSigningThreshold = 1
+                        , icNextKeys = [commitment]
+                        , icNextThreshold = 1
+                        , icConfig = []
+                        , icAnchors = []
+                        }
+                evt = mkInception cfg
+                evtBytes = serializeEvent evt
+                sigBytes = sign kp evtBytes
+                sigCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519Sig
+                            , raw = sigBytes
+                            }
+            pure
+                ( InceptionSubmission
+                    { isEventText =
+                        TE.decodeUtf8 evtBytes
+                    , isSignatures = [(0, sigCesr)]
+                    }
+                , cesrKey
+                )
+
+-- --------------------------------------------------------
+-- validateInception tests
+-- --------------------------------------------------------
+
+testValidateInception :: TestTree
+testValidateInception =
+    testGroup
+        "validateInception"
+        [ testCase
+            "accepts valid inception"
+            testValidInception
+        , testCase
+            "rejects wrong prefix"
+            testWrongPrefix
+        , testCase
+            "rejects bad signature"
+            testBadSignature
+        , testCase
+            "parseInceptionValue roundtrip"
+            testParseInceptionValue
+        ]
+
+testValidInception :: IO ()
+testValidInception = do
+    kp <- generateKeyPair
+    (inception, prefix) <- mkTestInception kp
+    let mid = MemberId prefix
+    assertBool
+        "valid inception should be accepted"
+        ( isRight $
+            validateInception mid inception
+        )
+
+testWrongPrefix :: IO ()
+testWrongPrefix = do
+    kp <- generateKeyPair
+    (inception, _prefix) <- mkTestInception kp
+    -- Use a different prefix
+    other <- generateKeyPair
+    let otherCesr =
+            Cesr.encode $
+                Primitive
+                    { code = Ed25519PubKey
+                    , raw =
+                        publicKeyBytes
+                            (publicKey other)
+                    }
+        wrongMid = MemberId otherCesr
+    assertBool
+        "wrong prefix should be rejected"
+        ( isLeft $
+            validateInception wrongMid inception
+        )
+
+testBadSignature :: IO ()
+testBadSignature = do
+    kp <- generateKeyPair
+    (inception, prefix) <- mkTestInception kp
+    -- Corrupt the signature
+    let badSigs =
+            [(0, T.replicate 88 "A")]
+        badInception =
+            inception{isSignatures = badSigs}
+        mid = MemberId prefix
+    assertBool
+        "bad signature should be rejected"
+        ( isLeft $
+            validateInception mid badInception
+        )
+
+testParseInceptionValue :: IO ()
+testParseInceptionValue = do
+    kp <- generateKeyPair
+    (inception, _prefix) <- mkTestInception kp
+    let val :: Value
+        val =
+            object
+                [ "event"
+                    .= isEventText inception
+                , "signatures"
+                    .= isSignatures inception
+                ]
+    assertBool
+        "parseInceptionValue should succeed"
+        (isRight $ parseInceptionValue val)
+
+-- --------------------------------------------------------
+-- kelFromInception tests
+-- --------------------------------------------------------
+
+testKelFromInception :: TestTree
+testKelFromInception =
+    testGroup
+        "kelFromInception"
+        [ testCase
+            "creates KEL with 1 event"
+            testKelCreation
+        ]
+
+testKelCreation :: IO ()
+testKelCreation = do
+    kp <- generateKeyPair
+    (inception, _prefix) <- mkTestInception kp
+    let kel = kelFromInception inception
+    kelEventCount kel @?= 1

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -12,6 +12,7 @@ module Main (main) where
 import KelCircle.Test.BaseDecisions qualified
 import KelCircle.Test.Crypto qualified
 import KelCircle.Test.Gate qualified
+import KelCircle.Test.MemberKel qualified
 import KelCircle.Test.Processing qualified
 import KelCircle.Test.Proposals qualified
 import KelCircle.Test.Sequence qualified
@@ -28,4 +29,5 @@ main =
             , KelCircle.Test.Proposals.tests
             , KelCircle.Test.Processing.tests
             , KelCircle.Test.Crypto.tests
+            , KelCircle.Test.MemberKel.tests
             ]


### PR DESCRIPTION
## Summary

- Each `IntroduceMember` now requires a signed KERI inception event, validated and stored as the first entry in the member's Key Event Log
- New `KelCircle.MemberKel` module for inception parsing, validation (event type, seq num, key presence, CESR signatures, crypto verification), and KEL creation
- SQLite `member_kels` table with replay on store open, new `GET /members/:id/kel` endpoint
- Lean formalization: `MemberKel.lean` with 6 preservation theorems, `Processing.lean` updated with `memberKels` field and 7 KEL preservation proofs — all compile with no `sorry`

## Test plan

- [x] 65 unit tests pass (5 new for inception validation)
- [x] 25 E2E tests pass (4 new: bootstrap admin has KEL, introduced member has KEL, missing inception rejected, wrong key rejected)
- [x] Lean proofs compile with no sorry (13 theorems)
- [x] `just ci` green (format, lint, build, test, lean, docs)