### PR TITLE
feat: verify circle events as KERI interaction events

### DIFF
--- a/kel-circle.cabal
+++ b/kel-circle.cabal
@@ -47,6 +47,7 @@ library
     KelCircle.Events
     KelCircle.Fold
     KelCircle.Gate
+    KelCircle.InteractionVerify
     KelCircle.MemberKel
     KelCircle.Processing
     KelCircle.Proposals
@@ -94,6 +95,7 @@ test-suite unit-tests
     KelCircle.Test.Crypto
     KelCircle.Test.Gate
     KelCircle.Test.Generators
+    KelCircle.Test.InteractionVerify
     KelCircle.Test.MemberKel
     KelCircle.Test.Processing
     KelCircle.Test.Proposals

--- a/lean/KelCircle/MemberKel.lean
+++ b/lean/KelCircle/MemberKel.lean
@@ -127,6 +127,83 @@ theorem insert_preserves_kelNonEmpty
   | tail _ hk' => exact h k hk'
 
 -------------------------------------------------------------------
+-- Interaction event append
+-------------------------------------------------------------------
+
+-- Append a KEL event (interaction): increment event count
+def appendKelEvent (kels : MemberKels) (mid : MemberId)
+    : MemberKels :=
+  kels.map (fun k =>
+    if k.1 = mid
+    then (k.1, ⟨k.2.ownerId, k.2.eventCount + 1⟩)
+    else k)
+
+-- After append, the member's event count increases by 1
+theorem appendKelEvent_grows
+    (kels : MemberKels) (mid : MemberId)
+    (k : MemberId × MemberKel)
+    (hk : k ∈ kels) (heq : k.1 = mid) :
+    ∃ k', k' ∈ appendKelEvent kels mid
+      ∧ k'.1 = mid
+      ∧ k'.2.eventCount = k.2.eventCount + 1 := by
+  unfold appendKelEvent
+  refine ⟨(k.1, ⟨k.2.ownerId, k.2.eventCount + 1⟩),
+    List.mem_map.mpr ⟨k, hk, ?_⟩, heq, rfl⟩
+  simp [heq]
+
+-- Other members' KELs are unchanged
+theorem appendKelEvent_preserves_others
+    (kels : MemberKels) (mid : MemberId)
+    (k : MemberId × MemberKel)
+    (hk : k ∈ kels) (hne : k.1 ≠ mid) :
+    k ∈ appendKelEvent kels mid := by
+  unfold appendKelEvent
+  exact List.mem_map.mpr ⟨k, hk, if_neg hne⟩
+
+-- appendKelEvent preserves allMembersHaveKel
+theorem appendKelEvent_preserves_allMembersHaveKel
+    (members : List Member) (kels : MemberKels)
+    (mid : MemberId)
+    (h : allMembersHaveKel members kels) :
+    allMembersHaveKel members
+      (appendKelEvent kels mid) := by
+  intro m hm
+  obtain ⟨k, hk, heq⟩ := h m hm
+  by_cases hmid : k.1 = mid
+  · obtain ⟨k', hk'mem, hk'eq, _⟩ :=
+      appendKelEvent_grows kels mid k hk hmid
+    exact ⟨k', hk'mem,
+      hk'eq.trans (hmid.symm.trans heq)⟩
+  · exact ⟨k, appendKelEvent_preserves_others
+      kels mid k hk hmid, heq⟩
+
+-- appendKelEvent preserves kelOwnersMatch
+theorem appendKelEvent_preserves_kelOwnersMatch
+    (kels : MemberKels) (mid : MemberId)
+    (h : kelOwnersMatch kels) :
+    kelOwnersMatch (appendKelEvent kels mid) := by
+  unfold appendKelEvent kelOwnersMatch
+  intro k' hk'
+  obtain ⟨k, hk, hfk⟩ := List.mem_map.mp hk'
+  have h_own := h k hk
+  by_cases hmid : k.1 = mid
+  · rw [if_pos hmid] at hfk; rw [← hfk]; exact h_own
+  · rw [if_neg hmid] at hfk; rw [← hfk]; exact h_own
+
+-- appendKelEvent preserves kelNonEmpty
+theorem appendKelEvent_preserves_kelNonEmpty
+    (kels : MemberKels) (mid : MemberId)
+    (h : kelNonEmpty kels) :
+    kelNonEmpty (appendKelEvent kels mid) := by
+  unfold appendKelEvent kelNonEmpty
+  intro k' hk'
+  obtain ⟨k, hk, hfk⟩ := List.mem_map.mp hk'
+  have h_ne := h k hk
+  by_cases hmid : k.1 = mid
+  · rw [if_pos hmid] at hfk; rw [← hfk]; simp
+  · rw [if_neg hmid] at hfk; rw [← hfk]; exact h_ne
+
+-------------------------------------------------------------------
 -- Non-membership events don't affect KELs
 -------------------------------------------------------------------
 

--- a/lib/KelCircle/InteractionVerify.hs
+++ b/lib/KelCircle/InteractionVerify.hs
@@ -1,0 +1,110 @@
+{- |
+Module      : KelCircle.InteractionVerify
+Description : Interaction event signature verification
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Verifies that circle event submissions carry valid
+KERI interaction event signatures. Each non-sequencer
+submission must be signed as an interaction event
+appended to the signer's KEL.
+-}
+module KelCircle.InteractionVerify
+    ( -- * Verification
+      VerifyResult (..)
+    , verifyInteraction
+
+      -- * Building interaction bytes
+    , buildInteractionBytes
+    ) where
+
+import Data.Aeson (Value)
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import Data.Text qualified as T
+import KelCircle.MemberKel
+    ( KelEvent (..)
+    , KelKeyState (..)
+    )
+import Keri.Event.Interaction
+    ( InteractionConfig (..)
+    , mkInteraction
+    )
+import Keri.Event.Serialize (serializeEvent)
+import Keri.KeyState.Verify (verifySignatures)
+
+-- | Result of interaction event verification.
+data VerifyResult
+    = -- | Signature valid; here is the new KEL event
+      Verified KelEvent
+    | -- | Signature verification failed
+      VerifyFailed Text
+    deriving stock (Show)
+
+{- | Build interaction event bytes and verify the
+signature against the signer's current key state.
+
+On success, returns 'Verified' with the new 'KelEvent'
+ready to append to the signer's KEL. On failure,
+returns 'VerifyFailed' with a reason.
+-}
+verifyInteraction
+    :: KelKeyState
+    -- ^ Signer's current key state
+    -> Text
+    -- ^ CESR-encoded signature (subSignature)
+    -> Value
+    -- ^ Circle event as JSON anchor
+    -> Either Text VerifyResult
+verifyInteraction kks sig anchor = do
+    let evtBytes =
+            buildInteractionBytes
+                (kksPrefix kks)
+                (kksSeqNum kks + 1)
+                (kksLastDigest kks)
+                anchor
+        sigs = [(0, sig)]
+    case verifySignatures
+        (kksKeys kks)
+        (kksThreshold kks)
+        evtBytes
+        sigs of
+        Left err ->
+            Right . VerifyFailed $
+                "signature verification error: "
+                    <> T.pack err
+        Right False ->
+            Right $
+                VerifyFailed
+                    "signature threshold not met"
+        Right True ->
+            Right $
+                Verified
+                    KelEvent
+                        { keEventBytes = evtBytes
+                        , keSignatures = sigs
+                        }
+
+{- | Build the canonical serialized bytes for an
+interaction event. Exported for test helpers that need
+to construct bytes to sign.
+-}
+buildInteractionBytes
+    :: Text
+    -- ^ KERI AID prefix
+    -> Int
+    -- ^ Sequence number
+    -> Text
+    -- ^ Prior event digest
+    -> Value
+    -- ^ Anchor data (circle event JSON)
+    -> ByteString
+buildInteractionBytes prefix' seqNum priorDigest anchor =
+    serializeEvent $
+        mkInteraction
+            InteractionConfig
+                { ixPrefix = prefix'
+                , ixSequenceNumber = seqNum
+                , ixPriorDigest = priorDigest
+                , ixAnchors = [anchor]
+                }

--- a/lib/KelCircle/Server/JSON.hs
+++ b/lib/KelCircle/Server/JSON.hs
@@ -347,6 +347,21 @@ instance ToJSON ValidationError where
             , "memberId" .= mid
             , "reason" .= reason
             ]
+    toJSON (InteractionVerifyFailed mid reason) =
+        object
+            [ "error"
+                .= ( "interactionVerifyFailed"
+                        :: Text
+                   )
+            , "memberId" .= mid
+            , "reason" .= reason
+            ]
+    toJSON (SignerHasNoKel mid) =
+        object
+            [ "error"
+                .= ("signerHasNoKel" :: Text)
+            , "memberId" .= mid
+            ]
 
 -- --------------------------------------------------------
 -- Submission

--- a/lib/KelCircle/Validate.hs
+++ b/lib/KelCircle/Validate.hs
@@ -55,6 +55,10 @@ data ValidationError
       MissingInception MemberId
     | -- | Inception event validation failed
       InvalidInception MemberId Text
+    | -- | Interaction signature verification failed
+      InteractionVerifyFailed MemberId Text
+    | -- | Signer has no KEL (not yet introduced)
+      SignerHasNoKel MemberId
     deriving stock (Show, Eq)
 
 -- | Validate a base decision submission.

--- a/test/KelCircle/Test/InteractionVerify.hs
+++ b/test/KelCircle/Test/InteractionVerify.hs
@@ -1,0 +1,300 @@
+{- |
+Module      : KelCircle.Test.InteractionVerify
+Description : Unit tests for interaction event verification
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Tests for key state extraction, interaction event
+signature verification, and deterministic byte output.
+-}
+module KelCircle.Test.InteractionVerify (tests) where
+
+import Data.Aeson (Value, object, toJSON, (.=))
+import Data.Either (isLeft)
+import Data.Text (Text)
+import Data.Text qualified as T
+import KelCircle.InteractionVerify
+    ( VerifyResult (..)
+    , buildInteractionBytes
+    , verifyInteraction
+    )
+import KelCircle.MemberKel
+    ( KelEvent (..)
+    , KelKeyState (..)
+    , MemberKel (..)
+    , kelKeyState
+    )
+import Keri.Cesr.DerivationCode (DerivationCode (..))
+import Keri.Cesr.Encode qualified as Cesr
+import Keri.Cesr.Primitive (Primitive (..))
+import Keri.Crypto.Ed25519
+    ( KeyPair (..)
+    , generateKeyPair
+    , publicKeyBytes
+    , sign
+    )
+import Keri.Event.Inception
+    ( InceptionConfig (..)
+    , mkInception
+    )
+import Keri.Event.Interaction
+    ( InteractionConfig (..)
+    , mkInteraction
+    )
+import Keri.Event.Serialize (serializeEvent)
+import Keri.KeyState.PreRotation (commitKey)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+    ( assertBool
+    , testCase
+    , (@?=)
+    )
+
+-- | All interaction verify unit tests.
+tests :: TestTree
+tests =
+    testGroup
+        "InteractionVerify"
+        [ testGroup
+            "kelKeyState"
+            [ testCase
+                "extracts from inception-only KEL"
+                testKelKeyStateInception
+            , testCase
+                "extracts from multi-event KEL"
+                testKelKeyStateMultiEvent
+            , testCase
+                "fails on empty KEL"
+                testKelKeyStateEmpty
+            ]
+        , testGroup
+            "verifyInteraction"
+            [ testCase
+                "succeeds with valid sig"
+                testVerifyValid
+            , testCase
+                "fails with wrong sig"
+                testVerifyWrongSig
+            ]
+        , testGroup
+            "buildInteractionBytes"
+            [ testCase
+                "deterministic output"
+                testDeterministic
+            ]
+        ]
+
+-- --------------------------------------------------------
+-- Test helpers
+-- --------------------------------------------------------
+
+-- | Create a test inception KEL for a keypair.
+mkTestKel :: IO (MemberKel, Text, KeyPair)
+mkTestKel = do
+    kp <- generateKeyPair
+    let cesrKey =
+            Cesr.encode $
+                Primitive
+                    { code = Ed25519PubKey
+                    , raw =
+                        publicKeyBytes (publicKey kp)
+                    }
+    nextKp <- generateKeyPair
+    let nextCesr =
+            Cesr.encode $
+                Primitive
+                    { code = Ed25519PubKey
+                    , raw =
+                        publicKeyBytes
+                            (publicKey nextKp)
+                    }
+    case commitKey nextCesr of
+        Left err -> error $ "commitKey: " <> err
+        Right commitment -> do
+            let cfg =
+                    InceptionConfig
+                        { icKeys = [cesrKey]
+                        , icSigningThreshold = 1
+                        , icNextKeys = [commitment]
+                        , icNextThreshold = 1
+                        , icConfig = []
+                        , icAnchors = []
+                        }
+                evt = mkInception cfg
+                evtBytes = serializeEvent evt
+                sigBytes = sign kp evtBytes
+                sigCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519Sig
+                            , raw = sigBytes
+                            }
+                kel =
+                    MemberKel
+                        [ KelEvent
+                            { keEventBytes = evtBytes
+                            , keSignatures =
+                                [(0, sigCesr)]
+                            }
+                        ]
+            pure (kel, cesrKey, kp)
+
+-- --------------------------------------------------------
+-- kelKeyState tests
+-- --------------------------------------------------------
+
+testKelKeyStateInception :: IO ()
+testKelKeyStateInception = do
+    (kel, cesrKey, _kp) <- mkTestKel
+    case kelKeyState kel of
+        Left err ->
+            error $ "kelKeyState failed: " <> T.unpack err
+        Right kks -> do
+            -- Prefix should be a SAID (starts with E)
+            assertBool
+                "prefix is not empty"
+                (T.length (kksPrefix kks) > 0)
+            kksSeqNum kks @?= 0
+            assertBool
+                "digest is not empty"
+                (T.length (kksLastDigest kks) > 0)
+            kksKeys kks @?= [cesrKey]
+            kksThreshold kks @?= 1
+
+testKelKeyStateMultiEvent :: IO ()
+testKelKeyStateMultiEvent = do
+    (kel@(MemberKel [icpEvt]), _cesrKey, kp) <-
+        mkTestKel
+    case kelKeyState kel of
+        Left err ->
+            error $ "kelKeyState failed: " <> T.unpack err
+        Right kks0 -> do
+            -- Build an interaction event
+            let anchor :: Value
+                anchor = object ["test" .= ("data" :: Text)]
+                ixnEvt =
+                    mkInteraction
+                        InteractionConfig
+                            { ixPrefix = kksPrefix kks0
+                            , ixSequenceNumber = 1
+                            , ixPriorDigest =
+                                kksLastDigest kks0
+                            , ixAnchors = [anchor]
+                            }
+                ixnBytes = serializeEvent ixnEvt
+                sigBytes = sign kp ixnBytes
+                sigCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519Sig
+                            , raw = sigBytes
+                            }
+                ixnKe =
+                    KelEvent
+                        { keEventBytes = ixnBytes
+                        , keSignatures =
+                            [(0, sigCesr)]
+                        }
+                multiKel = MemberKel [icpEvt, ixnKe]
+            case kelKeyState multiKel of
+                Left err ->
+                    error $
+                        "kelKeyState multi failed: "
+                            <> T.unpack err
+                Right kks1 -> do
+                    kksSeqNum kks1 @?= 1
+                    -- Digest should differ from icp
+                    assertBool
+                        "digest changed"
+                        ( kksLastDigest kks1
+                            /= kksLastDigest kks0
+                        )
+                    -- Keys unchanged
+                    kksKeys kks1 @?= kksKeys kks0
+
+testKelKeyStateEmpty :: IO ()
+testKelKeyStateEmpty =
+    assertBool
+        "empty KEL fails"
+        (isLeft $ kelKeyState (MemberKel []))
+
+-- --------------------------------------------------------
+-- verifyInteraction tests
+-- --------------------------------------------------------
+
+testVerifyValid :: IO ()
+testVerifyValid = do
+    (kel, _cesrKey, kp) <- mkTestKel
+    case kelKeyState kel of
+        Left err ->
+            error $
+                "kelKeyState failed: "
+                    <> T.unpack err
+        Right kks -> do
+            let anchor = toJSON ("hello" :: Text)
+                ixnBytes =
+                    buildInteractionBytes
+                        (kksPrefix kks)
+                        (kksSeqNum kks + 1)
+                        (kksLastDigest kks)
+                        anchor
+                sigBytes = sign kp ixnBytes
+                sigCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519Sig
+                            , raw = sigBytes
+                            }
+            case verifyInteraction kks sigCesr anchor of
+                Right (Verified _) -> pure ()
+                Right (VerifyFailed reason) ->
+                    error $
+                        "expected Verified, got: "
+                            <> T.unpack reason
+                Left err ->
+                    error $
+                        "verifyInteraction error: "
+                            <> T.unpack err
+
+testVerifyWrongSig :: IO ()
+testVerifyWrongSig = do
+    (kel, _cesrKey, _kp) <- mkTestKel
+    case kelKeyState kel of
+        Left err ->
+            error $
+                "kelKeyState failed: "
+                    <> T.unpack err
+        Right kks -> do
+            let anchor = toJSON ("hello" :: Text)
+                fakeSig = T.replicate 88 "A"
+            case verifyInteraction kks fakeSig anchor of
+                Right (VerifyFailed _) -> pure ()
+                Right (Verified _) ->
+                    error "expected VerifyFailed"
+                Left _ ->
+                    -- Error in CESR decode is also fine
+                    pure ()
+
+-- --------------------------------------------------------
+-- buildInteractionBytes tests
+-- --------------------------------------------------------
+
+testDeterministic :: IO ()
+testDeterministic = do
+    let prefix' = "Etest-prefix-1234"
+        seqNum = 5
+        digest = "Etest-digest-5678"
+        anchor = toJSON ("deterministic" :: Text)
+        bytes1 =
+            buildInteractionBytes
+                prefix'
+                seqNum
+                digest
+                anchor
+        bytes2 =
+            buildInteractionBytes
+                prefix'
+                seqNum
+                digest
+                anchor
+    bytes1 @?= bytes2

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -12,6 +12,7 @@ module Main (main) where
 import KelCircle.Test.BaseDecisions qualified
 import KelCircle.Test.Crypto qualified
 import KelCircle.Test.Gate qualified
+import KelCircle.Test.InteractionVerify qualified
 import KelCircle.Test.MemberKel qualified
 import KelCircle.Test.Processing qualified
 import KelCircle.Test.Proposals qualified
@@ -30,4 +31,5 @@ main =
             , KelCircle.Test.Processing.tests
             , KelCircle.Test.Crypto.tests
             , KelCircle.Test.MemberKel.tests
+            , KelCircle.Test.InteractionVerify.tests
             ]


### PR DESCRIPTION
Closes #18

## Summary

- Every non-sequencer circle event submission must carry a valid Ed25519 signature over a KERI interaction event, verified against the signer's current key state from their KEL
- New `KelCircle.InteractionVerify` module with `verifyInteraction` and `buildInteractionBytes`
- Lean formalization: `appendKelEvent` operation with 5 preservation theorems (no sorry)

## Test plan

- [x] 71 unit tests pass (6 new InteractionVerify tests)
- [x] 30 E2E tests pass (5 new interaction verification tests)
- [x] Lean builds clean
- [x] `just ci` green