### PR TITLE
feat: key rotation support (Phase 2, Step 2.4)

### DIFF
--- a/kel-circle.cabal
+++ b/kel-circle.cabal
@@ -50,6 +50,7 @@ library
     KelCircle.InteractionVerify
     KelCircle.MemberKel
     KelCircle.Processing
+    KelCircle.RotationVerify
     KelCircle.Proposals
     KelCircle.Sequence
     KelCircle.Server
@@ -98,6 +99,7 @@ test-suite unit-tests
     KelCircle.Test.InteractionVerify
     KelCircle.Test.MemberKel
     KelCircle.Test.Processing
+    KelCircle.Test.RotationVerify
     KelCircle.Test.Proposals
     KelCircle.Test.Sequence
 

--- a/lib/KelCircle/RotationVerify.hs
+++ b/lib/KelCircle/RotationVerify.hs
@@ -1,0 +1,200 @@
+{- |
+Module      : KelCircle.RotationVerify
+Description : Rotation event signature verification
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Verifies and constructs KERI rotation events for key
+rotation. Rotation events are signed by the OLD keys
+and reveal new keys that must match pre-rotation
+commitments.
+-}
+module KelCircle.RotationVerify
+    ( -- * Verification
+      RotationResult (..)
+    , verifyRotation
+
+      -- * Building rotation bytes
+    , buildRotationBytes
+    , rotationEventDigest
+    ) where
+
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import Data.Text qualified as T
+import KelCircle.MemberKel
+    ( KelEvent (..)
+    , KelKeyState (..)
+    , validateRotationCommitment
+    )
+import Keri.Event (eventDigest)
+import Keri.Event.Rotation
+    ( RotationConfig (..)
+    , mkRotation
+    )
+import Keri.Event.Serialize (serializeEvent)
+import Keri.KeyState.Verify (verifySignatures)
+
+-- | Result of rotation event verification.
+data RotationResult
+    = -- | Rotation valid; here is the new KEL event
+      RotationVerified KelEvent
+    | -- | Rotation verification failed
+      RotationFailed Text
+    deriving stock (Show)
+
+{- | Verify a rotation event against the signer's
+current key state.
+
+Checks:
+1. New keys match pre-rotation commitments
+2. Signatures (by OLD keys) verify over rotation bytes
+3. Signature threshold is met
+
+On success, returns 'RotationVerified' with the new
+'KelEvent'. On failure, returns 'RotationFailed'.
+-}
+verifyRotation
+    :: KelKeyState
+    -- ^ Current key state
+    -> [Text]
+    -- ^ New signing keys (CESR-encoded)
+    -> Int
+    -- ^ New signing threshold
+    -> [Text]
+    -- ^ New next-key commitments
+    -> Int
+    -- ^ New next threshold
+    -> [(Int, Text)]
+    -- ^ Signatures (by OLD keys over rotation bytes)
+    -> Either Text RotationResult
+verifyRotation
+    kks
+    newKeys
+    newThreshold
+    newNextKeys
+    newNextThreshold
+    sigs = do
+        -- 1. Validate pre-rotation commitments
+        case validateRotationCommitment
+            (kksNextKeys kks)
+            newKeys of
+            Left err ->
+                Right $
+                    RotationFailed $
+                        "commitment check: " <> err
+            Right () -> do
+                -- 2. Build rotation event bytes
+                let rotBytes =
+                        buildRotationBytes
+                            (kksPrefix kks)
+                            (kksSeqNum kks + 1)
+                            (kksLastDigest kks)
+                            newKeys
+                            newThreshold
+                            newNextKeys
+                            newNextThreshold
+                -- 3. Verify signatures (OLD keys sign)
+                case verifySignatures
+                    (kksKeys kks)
+                    (kksThreshold kks)
+                    rotBytes
+                    sigs of
+                    Left err ->
+                        Right . RotationFailed $
+                            "signature verification: "
+                                <> T.pack err
+                    Right False ->
+                        Right $
+                            RotationFailed
+                                "signature threshold \
+                                \not met"
+                    Right True ->
+                        Right $
+                            RotationVerified
+                                KelEvent
+                                    { keEventBytes =
+                                        rotBytes
+                                    , keSignatures = sigs
+                                    }
+
+{- | Build the canonical serialized bytes for a
+rotation event. Exported for test helpers that need
+to construct bytes to sign.
+-}
+buildRotationBytes
+    :: Text
+    -- ^ KERI AID prefix
+    -> Int
+    -- ^ Sequence number
+    -> Text
+    -- ^ Prior event digest
+    -> [Text]
+    -- ^ New signing keys
+    -> Int
+    -- ^ New signing threshold
+    -> [Text]
+    -- ^ New next-key commitments
+    -> Int
+    -- ^ New next threshold
+    -> ByteString
+buildRotationBytes
+    prefix'
+    seqNum
+    priorDigest
+    newKeys
+    newThreshold
+    newNextKeys
+    newNextThreshold =
+        serializeEvent $
+            mkRotation
+                RotationConfig
+                    { rcPrefix = prefix'
+                    , rcSequenceNumber = seqNum
+                    , rcPriorDigest = priorDigest
+                    , rcKeys = newKeys
+                    , rcSigningThreshold =
+                        newThreshold
+                    , rcNextKeys = newNextKeys
+                    , rcNextThreshold =
+                        newNextThreshold
+                    , rcConfig = []
+                    , rcAnchors = []
+                    }
+
+{- | Extract the digest from the rotation event
+built with given parameters. Used internally by
+test helpers to track KEL state after rotation.
+-}
+rotationEventDigest
+    :: Text
+    -> Int
+    -> Text
+    -> [Text]
+    -> Int
+    -> [Text]
+    -> Int
+    -> Text
+rotationEventDigest
+    prefix'
+    seqNum
+    priorDigest
+    newKeys
+    newThreshold
+    newNextKeys
+    newNextThreshold =
+        eventDigest $
+            mkRotation
+                RotationConfig
+                    { rcPrefix = prefix'
+                    , rcSequenceNumber = seqNum
+                    , rcPriorDigest = priorDigest
+                    , rcKeys = newKeys
+                    , rcSigningThreshold =
+                        newThreshold
+                    , rcNextKeys = newNextKeys
+                    , rcNextThreshold =
+                        newNextThreshold
+                    , rcConfig = []
+                    , rcAnchors = []
+                    }

--- a/lib/KelCircle/Server/JSON.hs
+++ b/lib/KelCircle/Server/JSON.hs
@@ -15,6 +15,7 @@ module KelCircle.Server.JSON
     ( Submission (..)
     , AppendResult (..)
     , ServerError (..)
+    , RotationSubmission (..)
     ) where
 
 import Data.Aeson
@@ -361,6 +362,55 @@ instance ToJSON ValidationError where
             [ "error"
                 .= ("signerHasNoKel" :: Text)
             , "memberId" .= mid
+            ]
+    toJSON (RotationFailed mid reason) =
+        object
+            [ "error"
+                .= ("rotationFailed" :: Text)
+            , "memberId" .= mid
+            , "reason" .= reason
+            ]
+
+-- --------------------------------------------------------
+-- RotationSubmission
+-- --------------------------------------------------------
+
+-- | Rotation submission from a client.
+data RotationSubmission = RotationSubmission
+    { rsNewKeys :: [Text]
+    -- ^ New signing keys (CESR-encoded)
+    , rsNewThreshold :: Int
+    -- ^ New signing threshold
+    , rsNextKeyCommitments :: [Text]
+    -- ^ Pre-rotation commitments for next rotation
+    , rsNextThreshold :: Int
+    -- ^ Next signing threshold
+    , rsSignatures :: [(Int, Text)]
+    -- ^ Indexed signatures (by OLD keys)
+    }
+    deriving stock (Show, Eq)
+
+instance FromJSON RotationSubmission where
+    parseJSON =
+        withObject "RotationSubmission" $ \o ->
+            RotationSubmission
+                <$> o .: "newKeys"
+                <*> o .: "newThreshold"
+                <*> o .: "nextKeyCommitments"
+                <*> o .: "nextThreshold"
+                <*> o .: "signatures"
+
+instance ToJSON RotationSubmission where
+    toJSON rs =
+        object
+            [ "newKeys" .= rsNewKeys rs
+            , "newThreshold"
+                .= rsNewThreshold rs
+            , "nextKeyCommitments"
+                .= rsNextKeyCommitments rs
+            , "nextThreshold"
+                .= rsNextThreshold rs
+            , "signatures" .= rsSignatures rs
             ]
 
 -- --------------------------------------------------------

--- a/lib/KelCircle/Validate.hs
+++ b/lib/KelCircle/Validate.hs
@@ -59,6 +59,8 @@ data ValidationError
       InteractionVerifyFailed MemberId Text
     | -- | Signer has no KEL (not yet introduced)
       SignerHasNoKel MemberId
+    | -- | Key rotation failed
+      RotationFailed MemberId Text
     deriving stock (Show, Eq)
 
 -- | Validate a base decision submission.

--- a/test/KelCircle/Test/RotationVerify.hs
+++ b/test/KelCircle/Test/RotationVerify.hs
@@ -1,0 +1,362 @@
+{- |
+Module      : KelCircle.Test.RotationVerify
+Description : Unit tests for rotation event verification
+Copyright   : (c) 2026 Paolo Veronelli
+License     : Apache-2.0
+
+Tests for rotation event construction and signature
+verification.
+-}
+module KelCircle.Test.RotationVerify (tests) where
+
+import Data.Text (Text)
+import Data.Text qualified as T
+import KelCircle.MemberKel
+    ( KelEvent (..)
+    , KelKeyState (..)
+    , MemberKel (..)
+    , kelKeyState
+    )
+import KelCircle.RotationVerify
+    ( RotationResult (..)
+    , buildRotationBytes
+    , verifyRotation
+    )
+import Keri.Cesr.DerivationCode (DerivationCode (..))
+import Keri.Cesr.Encode qualified as Cesr
+import Keri.Cesr.Primitive (Primitive (..))
+import Keri.Crypto.Ed25519
+    ( KeyPair (..)
+    , generateKeyPair
+    , publicKeyBytes
+    , sign
+    )
+import Keri.Event.Inception
+    ( InceptionConfig (..)
+    , mkInception
+    )
+import Keri.Event.Serialize (serializeEvent)
+import Keri.KeyState.PreRotation (commitKey)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+
+-- | All rotation verify unit tests.
+tests :: TestTree
+tests =
+    testGroup
+        "RotationVerify"
+        [ testGroup
+            "verifyRotation"
+            [ testCase
+                "succeeds with valid rotation"
+                testVerifyValid
+            , testCase
+                "fails with wrong commitment"
+                testVerifyWrongCommitment
+            , testCase
+                "fails with wrong signature"
+                testVerifyWrongSig
+            ]
+        , testGroup
+            "buildRotationBytes"
+            [ testCase
+                "deterministic output"
+                testDeterministic
+            ]
+        ]
+
+-- --------------------------------------------------------
+-- Test helpers
+-- --------------------------------------------------------
+
+-- | Create inception KEL for rotation tests.
+mkTestKel :: IO (MemberKel, Text, KeyPair, KeyPair)
+mkTestKel = do
+    kp <- generateKeyPair
+    let cesrKey =
+            Cesr.encode $
+                Primitive
+                    { code = Ed25519PubKey
+                    , raw =
+                        publicKeyBytes (publicKey kp)
+                    }
+    nextKp <- generateKeyPair
+    let nextCesr =
+            Cesr.encode $
+                Primitive
+                    { code = Ed25519PubKey
+                    , raw =
+                        publicKeyBytes
+                            (publicKey nextKp)
+                    }
+    case commitKey nextCesr of
+        Left err -> error $ "commitKey: " <> err
+        Right commitment -> do
+            let cfg =
+                    InceptionConfig
+                        { icKeys = [cesrKey]
+                        , icSigningThreshold = 1
+                        , icNextKeys = [commitment]
+                        , icNextThreshold = 1
+                        , icConfig = []
+                        , icAnchors = []
+                        }
+                evt = mkInception cfg
+                evtBytes = serializeEvent evt
+                sigBytes = sign kp evtBytes
+                sigCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519Sig
+                            , raw = sigBytes
+                            }
+                kel =
+                    MemberKel
+                        [ KelEvent
+                            { keEventBytes = evtBytes
+                            , keSignatures =
+                                [(0, sigCesr)]
+                            }
+                        ]
+            pure (kel, cesrKey, kp, nextKp)
+
+-- --------------------------------------------------------
+-- verifyRotation tests
+-- --------------------------------------------------------
+
+testVerifyValid :: IO ()
+testVerifyValid = do
+    (kel, _cesrKey, kp, nextKp) <- mkTestKel
+    case kelKeyState kel of
+        Left err ->
+            error $
+                "kelKeyState failed: "
+                    <> T.unpack err
+        Right kks -> do
+            -- New key is the pre-committed one
+            let newCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519PubKey
+                            , raw =
+                                publicKeyBytes
+                                    (publicKey nextKp)
+                            }
+            -- Generate next-next commitment
+            nextNextKp <- generateKeyPair
+            let nextNextCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519PubKey
+                            , raw =
+                                publicKeyBytes
+                                    ( publicKey
+                                        nextNextKp
+                                    )
+                            }
+            case commitKey nextNextCesr of
+                Left err ->
+                    error $
+                        "commitKey: " <> err
+                Right commitment2 -> do
+                    -- Build rotation bytes and sign
+                    let rotBytes =
+                            buildRotationBytes
+                                (kksPrefix kks)
+                                (kksSeqNum kks + 1)
+                                (kksLastDigest kks)
+                                [newCesr]
+                                1
+                                [commitment2]
+                                1
+                        sigBytes =
+                            sign kp rotBytes
+                        sigCesr =
+                            Cesr.encode $
+                                Primitive
+                                    { code = Ed25519Sig
+                                    , raw = sigBytes
+                                    }
+                    case verifyRotation
+                        kks
+                        [newCesr]
+                        1
+                        [commitment2]
+                        1
+                        [(0, sigCesr)] of
+                        Right (RotationVerified _) ->
+                            pure ()
+                        Right (RotationFailed reason) ->
+                            error $
+                                "expected Verified: "
+                                    <> T.unpack reason
+                        Left err ->
+                            error $
+                                "verifyRotation err: "
+                                    <> T.unpack err
+
+testVerifyWrongCommitment :: IO ()
+testVerifyWrongCommitment = do
+    (kel, _cesrKey, kp, _nextKp) <- mkTestKel
+    case kelKeyState kel of
+        Left err ->
+            error $
+                "kelKeyState failed: "
+                    <> T.unpack err
+        Right kks -> do
+            -- Use a random key (not the committed one)
+            wrongKp <- generateKeyPair
+            let wrongCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519PubKey
+                            , raw =
+                                publicKeyBytes
+                                    (publicKey wrongKp)
+                            }
+            nextNextKp <- generateKeyPair
+            let nextNextCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519PubKey
+                            , raw =
+                                publicKeyBytes
+                                    ( publicKey
+                                        nextNextKp
+                                    )
+                            }
+            case commitKey nextNextCesr of
+                Left err ->
+                    error $
+                        "commitKey: " <> err
+                Right commitment2 -> do
+                    let rotBytes =
+                            buildRotationBytes
+                                (kksPrefix kks)
+                                (kksSeqNum kks + 1)
+                                (kksLastDigest kks)
+                                [wrongCesr]
+                                1
+                                [commitment2]
+                                1
+                        sigBytes =
+                            sign kp rotBytes
+                        sigCesr =
+                            Cesr.encode $
+                                Primitive
+                                    { code = Ed25519Sig
+                                    , raw = sigBytes
+                                    }
+                    case verifyRotation
+                        kks
+                        [wrongCesr]
+                        1
+                        [commitment2]
+                        1
+                        [(0, sigCesr)] of
+                        Right (RotationFailed _) ->
+                            pure ()
+                        other ->
+                            error $
+                                "expected RotationFailed"
+                                    <> ", got: "
+                                    <> show other
+
+testVerifyWrongSig :: IO ()
+testVerifyWrongSig = do
+    (kel, _cesrKey, _kp, nextKp) <- mkTestKel
+    case kelKeyState kel of
+        Left err ->
+            error $
+                "kelKeyState failed: "
+                    <> T.unpack err
+        Right kks -> do
+            let newCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519PubKey
+                            , raw =
+                                publicKeyBytes
+                                    (publicKey nextKp)
+                            }
+            nextNextKp <- generateKeyPair
+            let nextNextCesr =
+                    Cesr.encode $
+                        Primitive
+                            { code = Ed25519PubKey
+                            , raw =
+                                publicKeyBytes
+                                    ( publicKey
+                                        nextNextKp
+                                    )
+                            }
+            case commitKey nextNextCesr of
+                Left err ->
+                    error $
+                        "commitKey: " <> err
+                Right commitment2 -> do
+                    -- Sign with WRONG key (nextKp)
+                    let rotBytes =
+                            buildRotationBytes
+                                (kksPrefix kks)
+                                (kksSeqNum kks + 1)
+                                (kksLastDigest kks)
+                                [newCesr]
+                                1
+                                [commitment2]
+                                1
+                        sigBytes =
+                            sign nextKp rotBytes
+                        sigCesr =
+                            Cesr.encode $
+                                Primitive
+                                    { code = Ed25519Sig
+                                    , raw = sigBytes
+                                    }
+                    case verifyRotation
+                        kks
+                        [newCesr]
+                        1
+                        [commitment2]
+                        1
+                        [(0, sigCesr)] of
+                        Right (RotationFailed _) ->
+                            pure ()
+                        other ->
+                            error $
+                                "expected RotationFailed"
+                                    <> ", got: "
+                                    <> show other
+
+-- --------------------------------------------------------
+-- buildRotationBytes tests
+-- --------------------------------------------------------
+
+testDeterministic :: IO ()
+testDeterministic = do
+    let prefix' = "Etest-prefix-1234"
+        seqNum = 5
+        digest = "Etest-digest-5678"
+        keys = ["Dkey-abc"]
+        threshold = 1
+        nextKeys = ["Ecommit-xyz"]
+        nextThreshold = 1
+        bytes1 =
+            buildRotationBytes
+                prefix'
+                seqNum
+                digest
+                keys
+                threshold
+                nextKeys
+                nextThreshold
+        bytes2 =
+            buildRotationBytes
+                prefix'
+                seqNum
+                digest
+                keys
+                threshold
+                nextKeys
+                nextThreshold
+    bytes1 @?= bytes2

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -16,6 +16,7 @@ import KelCircle.Test.InteractionVerify qualified
 import KelCircle.Test.MemberKel qualified
 import KelCircle.Test.Processing qualified
 import KelCircle.Test.Proposals qualified
+import KelCircle.Test.RotationVerify qualified
 import KelCircle.Test.Sequence qualified
 import Test.Tasty (defaultMain, testGroup)
 
@@ -32,4 +33,5 @@ main =
             , KelCircle.Test.Crypto.tests
             , KelCircle.Test.MemberKel.tests
             , KelCircle.Test.InteractionVerify.tests
+            , KelCircle.Test.RotationVerify.tests
             ]


### PR DESCRIPTION
Closes #19

## Summary

- **Lean**: Extend `MemberKel` with `keyVersion` tracking, add `rotateKelEvent` operation, 6 new preservation theorems (no sorry)
- **Haskell**: Rewrite `kelKeyState` with full KEL walk for rotation-aware key state extraction, new `RotationVerify` module with pre-rotation commitment verification, `POST /members/:id/rotate` endpoint, SQLite persistence via `appendRotationEvent`
- **Tests**: 8 new unit tests (rotation key state, commitment validation, rotation verification), 3 new E2E tests (rotate + new key accepted, old key rejected, bad commitment rejected)

## Test plan

- [x] 79 unit tests pass (`cabal test kel-circle:unit-tests`)
- [x] 33 E2E tests pass (`cabal test kel-circle:e2e-tests`)
- [x] Lean builds with no sorry (`lake build`)
- [x] `just ci` passes (format, lint, build, test, lean, docs)