### PR TITLE
refactor: move KELs off TVar, serve from SQLite

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -16,7 +16,11 @@ import Control.Exception (bracket)
 import Data.Text (Text, pack)
 import Data.Text.IO qualified as TIO
 import KelCircle.Events (BaseDecision)
-import KelCircle.Server (ServerConfig (..), mkApp)
+import KelCircle.Server
+    ( SSEMessage
+    , ServerConfig (..)
+    , mkApp
+    )
 import KelCircle.Store
     ( CircleStore
     , closeStore
@@ -51,7 +55,7 @@ runServer port dbPath passphrase =
         (openStore sid () trivialAppFold dbPath)
         closeStore
         $ \(store :: CircleStore () () ()) -> do
-            ch <- newBroadcastTChanIO
+            ch <- newBroadcastTChanIO @SSEMessage
             let logger msg =
                     TIO.hPutStrLn stderr msg
                         >> hFlush stderr

--- a/kel-circle.cabal
+++ b/kel-circle.cabal
@@ -64,7 +64,6 @@ library
     , aeson          >=2.1  && <3
     , base           >=4.18 && <5
     , bytestring     >=0.11 && <1
-    , containers     >=0.6  && <1
     , http-types     >=0.12 && <1
     , keri-hs
     , sqlite-simple  >=0.4  && <1

--- a/lib/KelCircle/Processing.hs
+++ b/lib/KelCircle/Processing.hs
@@ -28,14 +28,11 @@ module KelCircle.Processing
     , applyResolve
     ) where
 
-import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as Map
 import KelCircle.Events
     ( BaseDecision (..)
     , Resolution
     )
 import KelCircle.Gate (fullGate)
-import KelCircle.MemberKel (MemberKel)
 import KelCircle.Proposals qualified as P
 import KelCircle.State
     ( Circle (..)
@@ -68,8 +65,6 @@ data FullState g p r = FullState
     -- ^ Tracked proposals
     , fsNextSeq :: Int
     -- ^ Next sequence number
-    , fsMemberKels :: Map MemberId MemberKel
-    -- ^ Per-member Key Event Logs
     }
     deriving stock (Show, Eq)
 
@@ -85,7 +80,6 @@ initFullState sid initApp =
         , fsAppState = initApp
         , fsProposals = []
         , fsNextSeq = 1
-        , fsMemberKels = Map.empty
         }
   where
     genesis sid' =


### PR DESCRIPTION
Closes #22

## Summary

- Remove `fsMemberKels` from `FullState` — KELs don't participate in event processing (proven by 7 Lean `apply*_preserves_kels` theorems)
- KEL reads now query SQLite directly via `readMemberKel`
- Add `SSEMessage` sum type (`CircleEvent | KelUpdate`) for typed SSE broadcasts
- Enhance `GET /members/:id/kel` with `?after=N` query param and raw event data
- Make `verifyInteractionSig` IO-based with SQLite KEL lookup
- Broadcast KEL updates via SSE on introduction, interaction, and rotation
- Add 5 new E2E tests for KEL retrieval endpoint
- Remove unused `containers` dependency

## Test plan

- [x] All 79 unit tests pass
- [x] All 38 E2E tests pass (including 5 new KEL retrieval tests)
- [x] Lean proofs build unchanged (11 modules)
- [x] Format + lint clean
- [x] Docs build