### PR TITLE
feat: cache KelKeyState in FullState

### DIFF
--- a/kel-circle.cabal
+++ b/kel-circle.cabal
@@ -64,6 +64,7 @@ library
     , aeson          >=2.1  && <3
     , base           >=4.18 && <5
     , bytestring     >=0.11 && <1
+    , containers     >=0.6  && <1
     , http-types     >=0.12 && <1
     , keri-hs
     , sqlite-simple  >=0.4  && <1

--- a/lean/KelCircle/MemberKel.lean
+++ b/lean/KelCircle/MemberKel.lean
@@ -292,12 +292,14 @@ theorem rotateKelEvent_preserves_kelNonEmpty
   · rw [if_neg hmid] at hfk; rw [← hfk]; exact h_ne
 
 -------------------------------------------------------------------
--- Non-membership events don't affect KELs
+-- Combined invariant predicate
 -------------------------------------------------------------------
 
--- These theorems are proven in Processing.lean where the
--- apply functions are defined. The key property is that
--- applyBase, applyAppDecision, applyProposal, applyResponse,
--- and applyResolve all preserve the memberKels field.
+-- All KEL invariants hold together
+def kelInvariantsHold
+    (members : List Member) (kels : MemberKels) : Prop :=
+  allMembersHaveKel members kels
+    ∧ kelOwnersMatch kels
+    ∧ kelNonEmpty kels
 
 end KelCircle

--- a/lib/KelCircle/MemberKel.hs
+++ b/lib/KelCircle/MemberKel.hs
@@ -17,6 +17,7 @@ module KelCircle.MemberKel
       -- * Key state extraction
     , KelKeyState (..)
     , kelKeyState
+    , applyStoredEvent
 
       -- * Inception parsing
     , InceptionSubmission (..)

--- a/lib/KelCircle/Processing.hs
+++ b/lib/KelCircle/Processing.hs
@@ -28,11 +28,14 @@ module KelCircle.Processing
     , applyResolve
     ) where
 
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import KelCircle.Events
     ( BaseDecision (..)
     , Resolution
     )
 import KelCircle.Gate (fullGate)
+import KelCircle.MemberKel (KelKeyState)
 import KelCircle.Proposals qualified as P
 import KelCircle.State
     ( Circle (..)
@@ -65,6 +68,8 @@ data FullState g p r = FullState
     -- ^ Tracked proposals
     , fsNextSeq :: Int
     -- ^ Next sequence number
+    , fsKeyStates :: Map MemberId KelKeyState
+    -- ^ Cached key states (updated by Store)
     }
     deriving stock (Show, Eq)
 
@@ -80,6 +85,7 @@ initFullState sid initApp =
         , fsAppState = initApp
         , fsProposals = []
         , fsNextSeq = 1
+        , fsKeyStates = Map.empty
         }
   where
     genesis sid' =


### PR DESCRIPTION
Closes #25

## Summary

- Lean apply functions now take a `signer` parameter and update `memberKels` (append/insert/remove) with preservation proofs
- Haskell `FullState` gains `fsKeyStates :: Map MemberId KelKeyState`, populated on startup from SQLite and updated atomically on every mutation
- Server verification and rotation endpoints use O(log n) cache lookup instead of O(n) KEL walks from SQLite

## Changed files

| File | Change |
|------|--------|
| `lean/KelCircle/MemberKel.lean` | Add `kelInvariantsHold` combined predicate |
| `lean/KelCircle/Processing.lean` | Add signer param to apply functions, update memberKels, new preservation proofs |
| `lib/KelCircle/Processing.hs` | Add `fsKeyStates :: Map MemberId KelKeyState` to FullState |
| `lib/KelCircle/MemberKel.hs` | Export `applyStoredEvent` |
| `lib/KelCircle/Store.hs` | Populate/update cache in all mutation paths, export `lookupKelKeyState` |
| `lib/KelCircle/Server.hs` | Use cached key states in verification and rotation |
| `kel-circle.cabal` | Add `containers` to library deps |

## Test plan

- [x] `lake build` — Lean proofs compile, no sorry
- [x] `just ci` — format, lint, build, 79 unit tests, 40 E2E tests, docs all pass